### PR TITLE
Release v0.8.2: Add iOS artifacts to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-02-10
+
+### Added
+- iOS artifacts (`iosArm64`, `iosX64`, `iosSimulatorArm64`) now published to Maven Central
+
+### Changed
+- Publish workflow switched from Ubuntu to macOS runner to enable iOS artifact builds
+
 ## [0.8.1] - 2026-01-15
 
 ### Added
@@ -41,6 +49,7 @@ Initial implementation of the A2UI v0.8 rendering engine.
 - Event system: UserActionEvent, DataChangeEvent
 - Kotlin Multiplatform support: Android, iOS, JVM/Desktop
 
-[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/Contextable/a2ui-4k/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/Contextable/a2ui-4k/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Contextable/a2ui-4k/releases/tag/v0.8.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = "0.8.1"
+version = "0.8.2"

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,6 +1,6 @@
 project:
   name: a2ui-4k
-  version: 0.8.1
+  version: 0.8.2
   description: A2UI rendering engine for Compose Multiplatform
   links:
     homepage: https://github.com/contextable/a2ui-4k


### PR DESCRIPTION
## Summary
This release adds iOS platform artifacts (`iosArm64`, `iosX64`, `iosSimulatorArm64`) to Maven Central by switching the publish workflow from Ubuntu to macOS runner, which is required to build iOS targets.

## Changes
- **Version bump**: Updated version from 0.8.1 to 0.8.2 in `build.gradle.kts` and `jreleaser.yml`
- **iOS artifact publishing**: iOS targets are now included in Maven Central releases
- **CI/CD update**: Publish workflow switched from Ubuntu to macOS runner to enable iOS builds
- **Changelog**: Added v0.8.2 release notes documenting the new iOS artifacts and workflow change

## Implementation Details
- The macOS runner is necessary for building iOS artifacts in Kotlin Multiplatform projects
- This change enables users to depend on iOS variants of the library from Maven Central
- All three iOS architectures are now supported: ARM64 (physical devices), x86_64 (simulator Intel), and ARM64 (simulator Apple Silicon)

https://claude.ai/code/session_017bU6bRDQoj2RZXWGK7KP1H