### PR TITLE
Support publishing alpha/beta pre-releases from branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,15 @@ name: Publish to Maven Central
 on:
   workflow_dispatch:
     inputs:
+      channel:
+        description: 'Release channel'
+        required: true
+        type: choice
+        options:
+          - stable
+          - alpha
+          - beta
+        default: stable
       dry_run:
         description: 'Run in dry-run mode (test without uploading)'
         required: false
@@ -20,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history required for JReleaser
+          fetch-depth: 0  # Full history required for JReleaser and commit counting
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -99,7 +108,11 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo "🔍 Running publish script in dry-run mode..."
-          ./publish.sh --dry-run
+          CHANNEL_ARG=""
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            CHANNEL_ARG="--channel ${{ inputs.channel }}"
+          fi
+          ./publish.sh $CHANNEL_ARG --dry-run
 
       - name: Publish to Maven Central
         if: inputs.dry_run == false
@@ -111,7 +124,11 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo "🚀 Publishing to Maven Central..."
-          ./publish.sh
+          CHANNEL_ARG=""
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            CHANNEL_ARG="--channel ${{ inputs.channel }}"
+          fi
+          ./publish.sh $CHANNEL_ARG
 
       - name: Upload JReleaser logs
         if: always()
@@ -124,15 +141,39 @@ jobs:
       - name: Summary
         if: success() && inputs.dry_run == false
         run: |
-          VERSION=$(grep "^version = " build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(grep "^version = " build.gradle.kts | sed 's/version = .*"\(.*\)"/\1/')
+          CHANNEL="${{ inputs.channel }}"
+          BRANCH="${GITHUB_REF_NAME}"
+
+          if [ "$CHANNEL" != "stable" ]; then
+            if git rev-parse --verify origin/main >/dev/null 2>&1; then
+              BUILD_NUMBER=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo "1")
+            else
+              BUILD_NUMBER="1"
+            fi
+            [ "$BUILD_NUMBER" -eq "0" ] && BUILD_NUMBER=1
+            VERSION="${VERSION}-${CHANNEL}.${BUILD_NUMBER}"
+          fi
 
           echo "## ✅ Publishing Complete!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The a2ui-4k library has been published to Maven Central." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** \`${BRANCH}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Channel:** \`${CHANNEL}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Published Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "- \`com.contextable:a2ui-4k:${VERSION}\` (JVM, Android, iOS)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$CHANNEL" != "stable" ]; then
+            echo "### Usage" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`kotlin" >> $GITHUB_STEP_SUMMARY
+            echo "implementation(\"com.contextable:a2ui-4k:${VERSION}\")" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "**Note:** All platforms published including iOS artifacts in .klib format." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = "0.8.2"
+version = findProperty("publishVersion")?.toString() ?: "0.8.2"


### PR DESCRIPTION
Add --channel alpha|beta flag to publish.sh that computes a pre-release version (e.g., 0.8.2-alpha.3) using commits-ahead-of-main as the build number. The GitHub Actions workflow gains a channel dropdown so releases can be triggered from any branch. Gradle's version is now overridable via -PpublishVersion, and JReleaser's version is set via the JRELEASER_PROJECT_VERSION env var.