### PR TITLE
Upgrade A2UI protocol from v0.8 to v0.9 (clean break)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = "0.8.2"
+version = "0.9.0"

--- a/examples/catalog/src/commonMain/kotlin/com/contextable/a2ui4k/example/widgets/WidgetSamples.kt
+++ b/examples/catalog/src/commonMain/kotlin/com/contextable/a2ui4k/example/widgets/WidgetSamples.kt
@@ -17,11 +17,17 @@
 package com.contextable.a2ui4k.example.widgets
 
 /**
- * Sample definitions for each widget type (v0.8 format).
+ * Sample definitions for each widget type (v0.9 format).
  *
  * Each sample properly separates:
  * - components: Layout definitions with path bindings to data
  * - data: Actual content values
+ *
+ * v0.9 format uses flat component definitions:
+ * - `{"id":"x", "component":"Text", "text": {"path":"/msg"}, "variant":"h1"}`
+ * - Children are plain arrays: `["c1","c2"]`
+ * - Literal values are plain: `"foo"`, `42`, `true`
+ * - Path bindings remain: `{"path":"/x"}`
  */
 data class WidgetSample(
     val components: String,
@@ -55,11 +61,11 @@ object WidgetSamples {
     private val TEXT_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["h1", "h2", "body", "caption"]}}}},
-  {"id": "h1", "component": {"Text": {"text": {"path": "/heading1"}, "usageHint": "h1"}}},
-  {"id": "h2", "component": {"Text": {"text": {"path": "/heading2"}, "usageHint": "h2"}}},
-  {"id": "body", "component": {"Text": {"text": {"path": "/bodyText"}}}},
-  {"id": "caption", "component": {"Text": {"text": {"path": "/captionText"}, "usageHint": "caption"}}}
+  {"id": "root", "component": "Column", "children": ["h1", "h2", "body", "caption"]},
+  {"id": "h1", "component": "Text", "text": {"path": "/heading1"}, "variant": "h1"},
+  {"id": "h2", "component": "Text", "text": {"path": "/heading2"}, "variant": "h2"},
+  {"id": "body", "component": "Text", "text": {"path": "/bodyText"}},
+  {"id": "caption", "component": "Text", "text": {"path": "/captionText"}, "variant": "caption"}
 ]
         """.trimIndent(),
         data = """{
@@ -73,8 +79,8 @@ object WidgetSamples {
     private val TEXT_FIELD_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["input"]}}}},
-  {"id": "input", "component": {"TextField": {"label": {"path": "/inputLabel"}, "text": {"path": "/name"}}}}
+  {"id": "root", "component": "Column", "children": ["input"]},
+  {"id": "input", "component": "TextField", "label": {"path": "/inputLabel"}, "value": {"path": "/name"}}
 ]
         """.trimIndent(),
         data = """{
@@ -86,12 +92,12 @@ object WidgetSamples {
     private val BUTTON_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["primary-btn", "secondary-btn", "feedback"]}}}},
-  {"id": "primary-btn", "component": {"Button": {"child": "primary-text", "primary": true, "action": {"name": "submit", "dataUpdates": [{"path": "/lastClicked", "value": "Primary Button clicked!"}]}}}},
-  {"id": "primary-text", "component": {"Text": {"text": {"path": "/primaryLabel"}}}},
-  {"id": "secondary-btn", "component": {"Button": {"child": "secondary-text", "primary": false, "action": {"name": "cancel", "dataUpdates": [{"path": "/lastClicked", "value": "Secondary Button clicked!"}]}}}},
-  {"id": "secondary-text", "component": {"Text": {"text": {"path": "/secondaryLabel"}}}},
-  {"id": "feedback", "component": {"Text": {"text": {"path": "/lastClicked"}, "usageHint": "caption"}}}
+  {"id": "root", "component": "Column", "children": ["primary-btn", "secondary-btn", "feedback"]},
+  {"id": "primary-btn", "component": "Button", "child": "primary-text", "variant": "filled", "action": {"event": {"name": "submit", "context": {"source": "primary"}}, "dataUpdates": [{"path": "/lastClicked", "value": "Primary Button clicked!"}]}},
+  {"id": "primary-text", "component": "Text", "text": {"path": "/primaryLabel"}},
+  {"id": "secondary-btn", "component": "Button", "child": "secondary-text", "variant": "outlined", "action": {"event": {"name": "cancel", "context": {"source": "secondary"}}, "dataUpdates": [{"path": "/lastClicked", "value": "Secondary Button clicked!"}]}},
+  {"id": "secondary-text", "component": "Text", "text": {"path": "/secondaryLabel"}},
+  {"id": "feedback", "component": "Text", "text": {"path": "/lastClicked"}, "variant": "caption"}
 ]
         """.trimIndent(),
         data = """{
@@ -104,9 +110,9 @@ object WidgetSamples {
     private val IMAGE_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["label", "image"]}}}},
-  {"id": "label", "component": {"Text": {"text": {"path": "/label"}, "usageHint": "body"}}},
-  {"id": "image", "component": {"Image": {"url": {"path": "/imageUrl"}, "fit": "cover", "usageHint": "mediumFeature"}}}
+  {"id": "root", "component": "Column", "children": ["label", "image"]},
+  {"id": "label", "component": "Text", "text": {"path": "/label"}, "variant": "body"},
+  {"id": "image", "component": "Image", "url": {"path": "/imageUrl"}, "fit": "cover", "variant": "mediumFeature"}
 ]
         """.trimIndent(),
         data = """{
@@ -118,12 +124,12 @@ object WidgetSamples {
     private val ICON_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Row": {"children": {"explicitList": ["home", "settings", "search", "star", "favorite"]}}}},
-  {"id": "home", "component": {"Icon": {"name": {"path": "/icons/0"}}}},
-  {"id": "settings", "component": {"Icon": {"name": {"path": "/icons/1"}}}},
-  {"id": "search", "component": {"Icon": {"name": {"path": "/icons/2"}}}},
-  {"id": "star", "component": {"Icon": {"name": {"path": "/icons/3"}}}},
-  {"id": "favorite", "component": {"Icon": {"name": {"path": "/icons/4"}}}}
+  {"id": "root", "component": "Row", "children": ["home", "settings", "search", "star", "favorite"]},
+  {"id": "home", "component": "Icon", "name": {"path": "/icons/0"}},
+  {"id": "settings", "component": "Icon", "name": {"path": "/icons/1"}},
+  {"id": "search", "component": "Icon", "name": {"path": "/icons/2"}},
+  {"id": "star", "component": "Icon", "name": {"path": "/icons/3"}},
+  {"id": "favorite", "component": "Icon", "name": {"path": "/icons/4"}}
 ]
         """.trimIndent(),
         data = """{
@@ -134,10 +140,10 @@ object WidgetSamples {
     private val COLUMN_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"distribution": "spaceEvenly", "children": {"explicitList": ["item1", "item2", "item3"]}}}},
-  {"id": "item1", "component": {"Text": {"text": {"path": "/items/0"}}}},
-  {"id": "item2", "component": {"Text": {"text": {"path": "/items/1"}}}},
-  {"id": "item3", "component": {"Text": {"text": {"path": "/items/2"}}}}
+  {"id": "root", "component": "Column", "justify": "spaceEvenly", "children": ["item1", "item2", "item3"]},
+  {"id": "item1", "component": "Text", "text": {"path": "/items/0"}},
+  {"id": "item2", "component": "Text", "text": {"path": "/items/1"}},
+  {"id": "item3", "component": "Text", "text": {"path": "/items/2"}}
 ]
         """.trimIndent(),
         data = """{
@@ -148,10 +154,10 @@ object WidgetSamples {
     private val ROW_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Row": {"distribution": "spaceBetween", "children": {"explicitList": ["left", "center", "right"]}}}},
-  {"id": "left", "component": {"Text": {"text": {"path": "/positions/left"}}}},
-  {"id": "center", "component": {"Text": {"text": {"path": "/positions/center"}}}},
-  {"id": "right", "component": {"Text": {"text": {"path": "/positions/right"}}}}
+  {"id": "root", "component": "Row", "justify": "spaceBetween", "children": ["left", "center", "right"]},
+  {"id": "left", "component": "Text", "text": {"path": "/positions/left"}},
+  {"id": "center", "component": "Text", "text": {"path": "/positions/center"}},
+  {"id": "right", "component": "Text", "text": {"path": "/positions/right"}}
 ]
         """.trimIndent(),
         data = """{
@@ -166,9 +172,9 @@ object WidgetSamples {
     private val LIST_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"List": {"direction": "vertical", "children": {"template": {"dataBinding": "/items", "componentId": "item-template"}}}}},
-  {"id": "item-template", "component": {"Card": {"child": "item-text"}}},
-  {"id": "item-text", "component": {"Text": {"text": {"path": "/title"}}}}
+  {"id": "root", "component": "List", "direction": "vertical", "children": {"componentId": "item-template", "path": "/items"}},
+  {"id": "item-template", "component": "Card", "child": "item-text"},
+  {"id": "item-text", "component": "Text", "text": {"path": "/title"}}
 ]
         """.trimIndent(),
         data = """{
@@ -184,13 +190,13 @@ object WidgetSamples {
     private val CARD_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["card1", "card2"]}}}},
-  {"id": "card1", "component": {"Card": {"child": "card1-content"}}},
-  {"id": "card1-content", "component": {"Column": {"children": {"explicitList": ["card1-title", "card1-body"]}}}},
-  {"id": "card1-title", "component": {"Text": {"text": {"path": "/cards/0/title"}, "usageHint": "h3"}}},
-  {"id": "card1-body", "component": {"Text": {"text": {"path": "/cards/0/body"}}}},
-  {"id": "card2", "component": {"Card": {"child": "card2-text"}}},
-  {"id": "card2-text", "component": {"Text": {"text": {"path": "/cards/1/body"}}}}
+  {"id": "root", "component": "Column", "children": ["card1", "card2"]},
+  {"id": "card1", "component": "Card", "child": "card1-content"},
+  {"id": "card1-content", "component": "Column", "children": ["card1-title", "card1-body"]},
+  {"id": "card1-title", "component": "Text", "text": {"path": "/cards/0/title"}, "variant": "h3"},
+  {"id": "card1-body", "component": "Text", "text": {"path": "/cards/0/body"}},
+  {"id": "card2", "component": "Card", "child": "card2-text"},
+  {"id": "card2-text", "component": "Text", "text": {"path": "/cards/1/body"}}
 ]
         """.trimIndent(),
         data = """{
@@ -204,10 +210,10 @@ object WidgetSamples {
     private val DIVIDER_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["above", "divider", "below"]}}}},
-  {"id": "above", "component": {"Text": {"text": {"path": "/above"}}}},
-  {"id": "divider", "component": {"Divider": {}}},
-  {"id": "below", "component": {"Text": {"text": {"path": "/below"}}}}
+  {"id": "root", "component": "Column", "children": ["above", "divider", "below"]},
+  {"id": "above", "component": "Text", "text": {"path": "/above"}},
+  {"id": "divider", "component": "Divider"},
+  {"id": "below", "component": "Text", "text": {"path": "/below"}}
 ]
         """.trimIndent(),
         data = """{
@@ -219,10 +225,10 @@ object WidgetSamples {
     private val CHECKBOX_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["check1", "check2", "check3"]}}}},
-  {"id": "check1", "component": {"CheckBox": {"label": {"literalString": "Accept terms and conditions"}, "value": {"path": "/acceptTerms"}}}},
-  {"id": "check2", "component": {"CheckBox": {"label": {"literalString": "Subscribe to newsletter"}, "value": {"path": "/newsletter"}}}},
-  {"id": "check3", "component": {"CheckBox": {"label": {"literalString": "Enable notifications"}, "value": {"path": "/notifications"}}}}
+  {"id": "root", "component": "Column", "children": ["check1", "check2", "check3"]},
+  {"id": "check1", "component": "CheckBox", "label": "Accept terms and conditions", "value": {"path": "/acceptTerms"}},
+  {"id": "check2", "component": "CheckBox", "label": "Subscribe to newsletter", "value": {"path": "/newsletter"}},
+  {"id": "check3", "component": "CheckBox", "label": "Enable notifications", "value": {"path": "/notifications"}}
 ]
         """.trimIndent(),
         data = """{
@@ -235,10 +241,10 @@ object WidgetSamples {
     private val SLIDER_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["label", "slider", "value-text"]}}}},
-  {"id": "label", "component": {"Text": {"text": {"path": "/label"}, "usageHint": "body"}}},
-  {"id": "slider", "component": {"Slider": {"value": {"path": "/volume"}, "minValue": 0, "maxValue": 100}}},
-  {"id": "value-text", "component": {"Text": {"text": {"path": "/volume"}}}}
+  {"id": "root", "component": "Column", "children": ["label", "slider", "value-text"]},
+  {"id": "label", "component": "Text", "text": {"path": "/label"}, "variant": "body"},
+  {"id": "slider", "component": "Slider", "value": {"path": "/volume"}, "min": 0, "max": 100},
+  {"id": "value-text", "component": "Text", "text": {"path": "/volume"}}
 ]
         """.trimIndent(),
         data = """{
@@ -250,9 +256,9 @@ object WidgetSamples {
     private val DATE_TIME_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["label", "datetime"]}}}},
-  {"id": "label", "component": {"Text": {"text": {"path": "/label"}, "usageHint": "body"}}},
-  {"id": "datetime", "component": {"DateTimeInput": {"value": {"path": "/appointment"}, "enableDate": true, "enableTime": true}}}
+  {"id": "root", "component": "Column", "children": ["label", "datetime"]},
+  {"id": "label", "component": "Text", "text": {"path": "/label"}, "variant": "body"},
+  {"id": "datetime", "component": "DateTimeInput", "value": {"path": "/appointment"}, "enableDate": true, "enableTime": true}
 ]
         """.trimIndent(),
         data = """{
@@ -264,10 +270,10 @@ object WidgetSamples {
     private val TABS_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Tabs": {"tabItems": [{"title": {"path": "/tabs/0/title"}, "child": "tab1-content"}, {"title": {"path": "/tabs/1/title"}, "child": "tab2-content"}, {"title": {"path": "/tabs/2/title"}, "child": "tab3-content"}]}}},
-  {"id": "tab1-content", "component": {"Text": {"text": {"path": "/tabs/0/content"}}}},
-  {"id": "tab2-content", "component": {"Text": {"text": {"path": "/tabs/1/content"}}}},
-  {"id": "tab3-content", "component": {"Text": {"text": {"path": "/tabs/2/content"}}}}
+  {"id": "root", "component": "Tabs", "tabs": [{"title": {"path": "/tabs/0/title"}, "child": "tab1-content"}, {"title": {"path": "/tabs/1/title"}, "child": "tab2-content"}, {"title": {"path": "/tabs/2/title"}, "child": "tab3-content"}]},
+  {"id": "tab1-content", "component": "Text", "text": {"path": "/tabs/0/content"}},
+  {"id": "tab2-content", "component": "Text", "text": {"path": "/tabs/1/content"}},
+  {"id": "tab3-content", "component": "Text", "text": {"path": "/tabs/2/content"}}
 ]
         """.trimIndent(),
         data = """{
@@ -282,12 +288,12 @@ object WidgetSamples {
     private val MODAL_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Modal": {"entryPointChild": "trigger", "contentChild": "modal-content"}}},
-  {"id": "trigger", "component": {"Card": {"child": "trigger-text"}}},
-  {"id": "trigger-text", "component": {"Text": {"text": {"path": "/triggerLabel"}}}},
-  {"id": "modal-content", "component": {"Column": {"children": {"explicitList": ["modal-title", "modal-body"]}}}},
-  {"id": "modal-title", "component": {"Text": {"text": {"path": "/modal/title"}, "usageHint": "h3"}}},
-  {"id": "modal-body", "component": {"Text": {"text": {"path": "/modal/body"}}}}
+  {"id": "root", "component": "Modal", "trigger": "trigger", "content": "modal-content"},
+  {"id": "trigger", "component": "Card", "child": "trigger-text"},
+  {"id": "trigger-text", "component": "Text", "text": {"path": "/triggerLabel"}},
+  {"id": "modal-content", "component": "Column", "children": ["modal-title", "modal-body"]},
+  {"id": "modal-title", "component": "Text", "text": {"path": "/modal/title"}, "variant": "h3"},
+  {"id": "modal-body", "component": "Text", "text": {"path": "/modal/body"}}
 ]
         """.trimIndent(),
         data = """{
@@ -302,9 +308,9 @@ object WidgetSamples {
     private val VIDEO_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["label", "video"]}}}},
-  {"id": "label", "component": {"Text": {"text": {"path": "/label"}, "usageHint": "h2"}}},
-  {"id": "video", "component": {"Video": {"url": {"path": "/videoUrl"}}}}
+  {"id": "root", "component": "Column", "children": ["label", "video"]},
+  {"id": "label", "component": "Text", "text": {"path": "/label"}, "variant": "h2"},
+  {"id": "video", "component": "Video", "url": {"path": "/videoUrl"}}
 ]
         """.trimIndent(),
         data = """{
@@ -316,9 +322,9 @@ object WidgetSamples {
     private val AUDIO_PLAYER_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Column": {"children": {"explicitList": ["label", "audio"]}}}},
-  {"id": "label", "component": {"Text": {"text": {"path": "/label"}, "usageHint": "h2"}}},
-  {"id": "audio", "component": {"AudioPlayer": {"url": {"path": "/audioUrl"}}}}
+  {"id": "root", "component": "Column", "children": ["label", "audio"]},
+  {"id": "label", "component": "Text", "text": {"path": "/label"}, "variant": "h2"},
+  {"id": "audio", "component": "AudioPlayer", "url": {"path": "/audioUrl"}}
 ]
         """.trimIndent(),
         data = """{
@@ -330,7 +336,7 @@ object WidgetSamples {
     private val MINIMAL_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Text": {"text": {"path": "/message"}}}}
+  {"id": "root", "component": "Text", "text": {"path": "/message"}}
 ]
         """.trimIndent(),
         data = """{"message": "Hello, A2UI!"}"""
@@ -339,7 +345,7 @@ object WidgetSamples {
     private val CUSTOM_SAMPLE = WidgetSample(
         components = """
 [
-  {"id": "root", "component": {"Text": {"text": {"path": "/message"}}}}
+  {"id": "root", "component": "Text", "text": {"path": "/message"}}
 ]
         """.trimIndent(),
         data = """{"message": "Edit this sample!"}"""

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/A2Ui.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/A2Ui.kt
@@ -21,7 +21,7 @@
  * A2UI (Agent-to-UI) surfaces. It implements the component model from
  * the A2UI protocol, enabling AI agents to generate dynamic UIs.
  *
- * a2ui-4k currently implements the A2UI v0.8 specification. The A2UI protocol
+ * a2ui-4k currently implements the A2UI v0.9 specification. The A2UI protocol
  * is under active development at [google/A2UI](https://github.com/google/A2UI).
  *
  * ## Quick Start
@@ -73,8 +73,9 @@ package com.contextable.a2ui4k
 public typealias Component = com.contextable.a2ui4k.model.Component
 public typealias UiDefinition = com.contextable.a2ui4k.model.UiDefinition
 public typealias UiEvent = com.contextable.a2ui4k.model.UiEvent
-public typealias UserActionEvent = com.contextable.a2ui4k.model.UserActionEvent
+public typealias ActionEvent = com.contextable.a2ui4k.model.ActionEvent
 public typealias DataChangeEvent = com.contextable.a2ui4k.model.DataChangeEvent
+public typealias ValidationError = com.contextable.a2ui4k.model.ValidationError
 public typealias Catalog = com.contextable.a2ui4k.model.Catalog
 public typealias CatalogItem = com.contextable.a2ui4k.model.CatalogItem
 public typealias DataContext = com.contextable.a2ui4k.model.DataContext

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/CoreCatalog.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/CoreCatalog.kt
@@ -20,7 +20,7 @@ import com.contextable.a2ui4k.catalog.widgets.AudioPlayerWidget
 import com.contextable.a2ui4k.catalog.widgets.ButtonWidget
 import com.contextable.a2ui4k.catalog.widgets.CardWidget
 import com.contextable.a2ui4k.catalog.widgets.CheckBoxWidget
-import com.contextable.a2ui4k.catalog.widgets.MultipleChoiceWidget
+import com.contextable.a2ui4k.catalog.widgets.ChoicePickerWidget
 import com.contextable.a2ui4k.catalog.widgets.ColumnWidget
 import com.contextable.a2ui4k.catalog.widgets.DateTimeInputWidget
 import com.contextable.a2ui4k.catalog.widgets.DividerWidget
@@ -40,7 +40,7 @@ import com.contextable.a2ui4k.model.Catalog
  * The core catalog of built-in A2UI widgets.
  *
  * This catalog provides the standard set of widgets defined in the
- * A2UI v0.8 protocol's standard_catalog_definition.json. Applications
+ * A2UI v0.9 protocol's standard_catalog.json. Applications
  * can use this catalog directly or combine it with custom catalogs
  * using the `+` operator.
  *
@@ -67,20 +67,8 @@ import com.contextable.a2ui4k.model.Catalog
  * - TextField: Text input field with label and data binding
  * - CheckBox: Boolean input with label
  * - Slider: Numeric range input
- * - MultipleChoice: Selection component
+ * - ChoicePicker: Selection component (single or multiple)
  * - DateTimeInput: Date/time picker
- *
- * ## Usage
- *
- * ```kotlin
- * A2UISurface(
- *     definition = uiDefinition,
- *     catalog = CoreCatalog
- * )
- *
- * // Or combine with custom catalog:
- * val combined = CoreCatalog + myCustomCatalog
- * ```
  *
  * @see com.contextable.a2ui4k.model.CatalogItem
  * @see com.contextable.a2ui4k.model.Catalog
@@ -100,7 +88,7 @@ val CoreCatalog: Catalog = Catalog.of(
     IconWidget,
     CheckBoxWidget,
     SliderWidget,
-    MultipleChoiceWidget,
+    ChoicePickerWidget,
     DateTimeInputWidget,
     TabsWidget,
     ModalWidget,
@@ -124,7 +112,7 @@ object CoreCatalogItems {
     val icon = IconWidget
     val checkBox = CheckBoxWidget
     val slider = SliderWidget
-    val multipleChoice = MultipleChoiceWidget
+    val choicePicker = ChoicePickerWidget
     val dateTimeInput = DateTimeInputWidget
     val tabs = TabsWidget
     val modal = ModalWidget

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/CardWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/CardWidget.kt
@@ -34,6 +34,7 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Card widget that wraps a child component in a Material 3 Card.
  *
+ * A2UI Protocol Properties (v0.9):
  * Matches A2UI protocol Card:
  * - Uses surface color from theme
  * - Applies 8dp internal padding around child

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/CheckBoxWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/CheckBoxWidget.kt
@@ -45,15 +45,15 @@ import kotlinx.serialization.json.JsonObject
 /**
  * CheckBox widget for boolean input.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - label (required): Display label for the checkbox
  * - value (optional): Boolean value, supports path binding for two-way data binding
  *
- * JSON Schema:
+ * JSON Schema (v0.9):
  * ```json
  * {
- *   "label": {"literalString": "Accept terms"},
- *   "value": {"path": "/form/accepted"}
+ *   "label": "Accept terms" | {"path": "/labels/terms"},
+ *   "value": {"path": "/form/accepted"} | true
  * }
  * ```
  */

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/DateTimeInputWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/DateTimeInputWidget.kt
@@ -54,17 +54,17 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * DateTimeInput widget for date and/or time input.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - value (required): Date/time value, supports path binding for two-way data binding
  * - enableDate (optional): Enable date picker (default true)
  * - enableTime (optional): Enable time picker (default false)
  *
- * JSON Schema:
+ * JSON Schema (v0.9):
  * ```json
  * {
  *   "value": {"path": "/form/date"},
- *   "enableDate": {"literalBoolean": true},
- *   "enableTime": {"literalBoolean": true}
+ *   "enableDate": true,
+ *   "enableTime": true
  * }
  * ```
  */

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/DividerWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/DividerWidget.kt
@@ -36,6 +36,8 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Divider widget that displays a thin line to separate content.
  *
+ * A2UI Protocol Properties (v0.9):
+ *
  * JSON Schema:
  * ```json
  * {

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/IconWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/IconWidget.kt
@@ -32,10 +32,13 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Icon widget that displays a Material icon from the predefined set.
  *
+ * A2UI Protocol Properties (v0.9):
+ * - name (required): Icon name from the predefined set
+ *
  * JSON Schema:
  * ```json
  * {
- *   "name": {"literalString": "home"} | {"path": "/icon/name"}
+ *   "name": "home" | {"path": "/icon/name"}
  * }
  * ```
  *

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ImageWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ImageWidget.kt
@@ -44,17 +44,17 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Image widget that displays an image from a URL.
  *
- * A2UI Protocol Properties:
- * - url (required): Image source as literalString or path
+ * A2UI Protocol Properties (v0.9):
+ * - url (required): Image source as string or path
  * - fit (optional): How image resizes - contain, cover, fill, none, scale-down
- * - usageHint (optional): Suggests intended size - icon, avatar, smallFeature, mediumFeature, largeFeature, header
+ * - variant (optional): Suggests intended size - icon, avatar, smallFeature, mediumFeature, largeFeature, header
  *
  * JSON Schema:
  * ```json
  * {
- *   "url": {"literalString": "https://example.com/image.jpg"} | {"path": "/item/imageUrl"},
+ *   "url": "https://example.com/image.jpg" | {"path": "/item/imageUrl"},
  *   "fit": "cover" | "contain" | "fill" | "none" | "scale-down" (optional),
- *   "usageHint": "icon" | "avatar" | "smallFeature" | "mediumFeature" | "largeFeature" | "header" (optional)
+ *   "variant": "icon" | "avatar" | "smallFeature" | "mediumFeature" | "largeFeature" | "header" (optional)
  * }
  * ```
  */
@@ -64,7 +64,7 @@ val ImageWidget = CatalogItem(
     ImageWidgetContent(data = data, dataContext = dataContext)
 }
 
-private val EXPECTED_PROPERTIES = setOf("url", "fit", "usageHint")
+private val EXPECTED_PROPERTIES = setOf("url", "fit", "variant")
 
 @Composable
 private fun ImageWidgetContent(
@@ -75,7 +75,7 @@ private fun ImageWidgetContent(
 
     val urlRef = DataReferenceParser.parseString(data["url"])
     val fitRef = DataReferenceParser.parseString(data["fit"])
-    val usageHintRef = DataReferenceParser.parseString(data["usageHint"])
+    val variantRef = DataReferenceParser.parseString(data["variant"])
 
     val url = when (urlRef) {
         is LiteralString -> urlRef.value
@@ -89,9 +89,9 @@ private fun ImageWidgetContent(
         else -> null
     }
 
-    val usageHint = when (usageHintRef) {
-        is LiteralString -> usageHintRef.value
-        is PathString -> dataContext.getString(usageHintRef.path)
+    val variant = when (variantRef) {
+        is LiteralString -> variantRef.value
+        is PathString -> dataContext.getString(variantRef.path)
         else -> null
     }
 
@@ -105,8 +105,8 @@ private fun ImageWidgetContent(
         else -> ContentScale.Crop // Default to cover behavior
     }
 
-    // Map usageHint to appropriate dimensions and shape
-    val (height, fillWidth, shape) = getImageDimensions(usageHint)
+    // Map variant to appropriate dimensions and shape
+    val (height, fillWidth, shape) = getImageDimensions(variant)
 
     if (url != null) {
         val sizeModifier = when {
@@ -145,12 +145,12 @@ private fun ImageWidgetContent(
 private val ImageCornerRadius = RoundedCornerShape(12.dp)
 
 /**
- * Maps A2UI usageHint to appropriate image dimensions and shape.
+ * Maps A2UI variant to appropriate image dimensions and shape.
  *
  * @return Triple of (height in dp or null, fillWidth boolean, shape or null)
  */
-private fun getImageDimensions(usageHint: String?): Triple<Dp?, Boolean, Shape?> {
-    return when (usageHint?.lowercase()) {
+private fun getImageDimensions(variant: String?): Triple<Dp?, Boolean, Shape?> {
+    return when (variant?.lowercase()) {
         "icon" -> Triple(24.dp, false, null) // Icons: no rounded corners
         "avatar" -> Triple(48.dp, false, CircleShape) // Avatars: circular
         "smallfeature" -> Triple(80.dp, true, ImageCornerRadius)

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ModalWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ModalWidget.kt
@@ -42,18 +42,18 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Modal widget for displaying dialog overlays.
  *
- * A2UI Protocol Properties (v0.8):
- * - entryPointChild (required): Component ID of the trigger element (e.g., a Button)
- * - contentChild (required): Component ID of the content to display in the modal
+ * A2UI Protocol Properties (v0.9):
+ * - trigger (required): Component ID of the trigger element (e.g., a Button)
+ * - content (required): Component ID of the content to display in the modal
  *
- * The modal opens when the entryPointChild is clicked.
+ * The modal opens when the trigger is clicked.
  *
  * JSON Schema:
  * ```json
  * {
  *   "component": "Modal",
- *   "entryPointChild": "open-modal-button",
- *   "contentChild": "modal-content"
+ *   "trigger": "open-modal-button",
+ *   "content": "modal-content"
  * }
  * ```
  */
@@ -68,7 +68,7 @@ val ModalWidget = CatalogItem(
     )
 }
 
-private val EXPECTED_PROPERTIES = setOf("entryPointChild", "contentChild")
+private val EXPECTED_PROPERTIES = setOf("trigger", "content")
 
 @Composable
 private fun ModalWidgetContent(
@@ -79,20 +79,20 @@ private fun ModalWidgetContent(
 ) {
     PropertyValidation.warnUnexpectedProperties("Modal", data, EXPECTED_PROPERTIES)
 
-    val entryPointRef = DataReferenceParser.parseComponentRef(data["entryPointChild"])
-    val contentRef = DataReferenceParser.parseComponentRef(data["contentChild"])
+    val triggerRef = DataReferenceParser.parseComponentRef(data["trigger"])
+    val contentRef = DataReferenceParser.parseComponentRef(data["content"])
 
-    val entryPointChildId = entryPointRef?.componentId
+    val triggerChildId = triggerRef?.componentId
     val contentChildId = contentRef?.componentId
 
     var showDialog by remember { mutableStateOf(false) }
 
-    // Render the entry point (trigger element)
-    if (entryPointChildId != null) {
+    // Render the trigger element
+    if (triggerChildId != null) {
         Box(
             modifier = Modifier.clickable { showDialog = true }
         ) {
-            buildChild(entryPointChildId)
+            buildChild(triggerChildId)
         }
     }
 

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/RowWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/RowWidget.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.contextable.a2ui4k.model.CatalogItem
 import com.contextable.a2ui4k.model.ChildBuilder
+import com.contextable.a2ui4k.model.ChildrenReference
 import com.contextable.a2ui4k.model.DataContext
 import com.contextable.a2ui4k.model.DataReferenceParser
 import com.contextable.a2ui4k.model.LiteralString
@@ -37,17 +38,17 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Row widget that arranges children horizontally.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - children (required): List of child component IDs
- * - distribution (optional): start, center, end, spaceBetween, spaceAround, spaceEvenly
- * - alignment (optional): start, center, end, stretch
+ * - justify (optional): start, center, end, spaceBetween, spaceAround, spaceEvenly
+ * - align (optional): start, center, end, stretch
  *
  * JSON Schema:
  * ```json
  * {
- *   "children": {"explicitList": ["child1", "child2"]},
- *   "distribution": {"literalString": "spaceBetween"},
- *   "alignment": {"literalString": "center"}
+ *   "children": ["child1", "child2"],
+ *   "justify": "spaceBetween",
+ *   "align": "center"
  * }
  * ```
  */
@@ -57,7 +58,7 @@ val RowWidget = CatalogItem(
     RowWidgetContent(data = data, buildChild = buildChild, dataContext = dataContext)
 }
 
-private val EXPECTED_PROPERTIES = setOf("children", "distribution", "alignment")
+private val EXPECTED_PROPERTIES = setOf("children", "justify", "align")
 
 @Composable
 private fun RowWidgetContent(
@@ -67,37 +68,37 @@ private fun RowWidgetContent(
 ) {
     PropertyValidation.warnUnexpectedProperties("Row", data, EXPECTED_PROPERTIES)
 
-    val childrenRef = DataReferenceParser.parseComponentArray(data["children"])
-    val children = childrenRef?.componentIds ?: emptyList()
+    val childrenRef = DataReferenceParser.parseChildren(data["children"])
+    val children = (childrenRef as? ChildrenReference.ExplicitList)?.componentIds ?: emptyList()
 
-    val distributionRef = DataReferenceParser.parseString(data["distribution"])
-    val distribution = when (distributionRef) {
-        is LiteralString -> distributionRef.value
-        is PathString -> dataContext.getString(distributionRef.path)
+    val justifyRef = DataReferenceParser.parseString(data["justify"])
+    val justify = when (justifyRef) {
+        is LiteralString -> justifyRef.value
+        is PathString -> dataContext.getString(justifyRef.path)
         else -> null
     }
 
-    val alignmentRef = DataReferenceParser.parseString(data["alignment"])
-    val alignment = when (alignmentRef) {
-        is LiteralString -> alignmentRef.value
-        is PathString -> dataContext.getString(alignmentRef.path)
+    val alignRef = DataReferenceParser.parseString(data["align"])
+    val align = when (alignRef) {
+        is LiteralString -> alignRef.value
+        is PathString -> dataContext.getString(alignRef.path)
         else -> null
     }
 
     val definition = LocalUiDefinition.current
 
-    // Apply fillMaxWidth only for distributions that need space to distribute.
+    // Apply fillMaxWidth only for justify values that need space to distribute.
     // This allows simple Rows to be centered by parent alignment, while
     // spaceAround/spaceBetween/etc. get full width to distribute children.
-    val needsFullWidth = distribution?.lowercase() in listOf(
+    val needsFullWidth = justify?.lowercase() in listOf(
         "spacebetween", "spacearound", "spaceevenly"
     )
     val modifier = if (needsFullWidth) Modifier.fillMaxWidth() else Modifier
 
     Row(
         modifier = modifier,
-        horizontalArrangement = parseHorizontalArrangement(distribution),
-        verticalAlignment = parseVerticalAlignment(alignment)
+        horizontalArrangement = parseHorizontalArrangement(justify),
+        verticalAlignment = parseVerticalAlignment(align)
     ) {
         children.forEach { childId ->
             val weight = definition?.components?.get(childId)?.weight
@@ -126,13 +127,13 @@ private fun RowScope.BuildWeightedChild(
 }
 
 /**
- * Parse horizontal arrangement from A2UI distribution values.
+ * Parse horizontal arrangement from A2UI justify values.
  *
- * Valid distribution values per A2UI v0.8 spec:
+ * Valid justify values per A2UI v0.9 spec:
  * start, center, end, spaceBetween, spaceAround, spaceEvenly
  */
-private fun parseHorizontalArrangement(distribution: String?): Arrangement.Horizontal {
-    return when (distribution?.lowercase()) {
+private fun parseHorizontalArrangement(justify: String?): Arrangement.Horizontal {
+    return when (justify?.lowercase()) {
         "start" -> Arrangement.Start
         "center" -> Arrangement.Center
         "end" -> Arrangement.End
@@ -144,9 +145,9 @@ private fun parseHorizontalArrangement(distribution: String?): Arrangement.Horiz
 }
 
 /**
- * Parse vertical alignment from A2UI alignment values.
+ * Parse vertical alignment from A2UI align values.
  *
- * Valid alignment values per A2UI v0.8 spec:
+ * Valid align values per A2UI v0.9 spec:
  * start, center, end, stretch
  */
 private fun parseVerticalAlignment(alignment: String?): Alignment.Vertical {

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/SliderWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/SliderWidget.kt
@@ -38,17 +38,17 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Slider widget for numeric range input.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - value (required): Current value, supports path binding for two-way data binding
- * - minValue (optional): Minimum value (default 0)
- * - maxValue (optional): Maximum value (default 100)
+ * - min (optional): Minimum value (default 0)
+ * - max (optional): Maximum value (default 100)
  *
- * JSON Schema:
+ * JSON Schema (v0.9):
  * ```json
  * {
  *   "value": {"path": "/settings/volume"},
- *   "minValue": {"literalNumber": 0},
- *   "maxValue": {"literalNumber": 100}
+ *   "min": 0,
+ *   "max": 100
  * }
  * ```
  */
@@ -63,7 +63,7 @@ val SliderWidget = CatalogItem(
     )
 }
 
-private val EXPECTED_PROPERTIES = setOf("value", "minValue", "maxValue")
+private val EXPECTED_PROPERTIES = setOf("value", "min", "max")
 
 @Composable
 private fun SliderWidgetContent(
@@ -75,22 +75,22 @@ private fun SliderWidgetContent(
     PropertyValidation.warnUnexpectedProperties("Slider", data, EXPECTED_PROPERTIES)
 
     val valueRef = DataReferenceParser.parseNumber(data["value"])
-    val minValueRef = DataReferenceParser.parseNumber(data["minValue"])
-    val maxValueRef = DataReferenceParser.parseNumber(data["maxValue"])
+    val minRef = DataReferenceParser.parseNumber(data["min"])
+    val maxRef = DataReferenceParser.parseNumber(data["max"])
 
     // Get surfaceId from UiDefinition
     val uiDefinition = LocalUiDefinition.current
     val surfaceId = uiDefinition?.surfaceId ?: "default"
 
-    val minValue = when (minValueRef) {
-        is LiteralNumber -> minValueRef.value.toFloat()
-        is PathNumber -> dataContext.getNumber(minValueRef.path)?.toFloat() ?: 0f
+    val minValue = when (minRef) {
+        is LiteralNumber -> minRef.value.toFloat()
+        is PathNumber -> dataContext.getNumber(minRef.path)?.toFloat() ?: 0f
         else -> 0f
     }
 
-    val maxValue = when (maxValueRef) {
-        is LiteralNumber -> maxValueRef.value.toFloat()
-        is PathNumber -> dataContext.getNumber(maxValueRef.path)?.toFloat() ?: 100f
+    val maxValue = when (maxRef) {
+        is LiteralNumber -> maxRef.value.toFloat()
+        is PathNumber -> dataContext.getNumber(maxRef.path)?.toFloat() ?: 100f
         else -> 100f
     }
 

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/TabsWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/TabsWidget.kt
@@ -47,12 +47,10 @@ import kotlinx.serialization.json.jsonPrimitive
  * ```json
  * {
  *   "component": "Tabs",
- *   "properties": {
- *     "tabItems": [
- *       {"title": "Tab 1", "child": "content_1"},
- *       {"title": "Tab 2", "child": "content_2"}
- *     ]
- *   }
+ *   "tabs": [
+ *     {"title": "Tab 1", "child": "content_1"},
+ *     {"title": "Tab 2", "child": "content_2"}
+ *   ]
  * }
  * ```
  */
@@ -67,7 +65,7 @@ val TabsWidget = CatalogItem(
     )
 }
 
-private val EXPECTED_PROPERTIES = setOf("tabItems")
+private val EXPECTED_PROPERTIES = setOf("tabs")
 
 @Composable
 private fun TabsWidgetContent(
@@ -78,9 +76,9 @@ private fun TabsWidgetContent(
 ) {
     PropertyValidation.warnUnexpectedProperties("Tabs", data, EXPECTED_PROPERTIES)
 
-    val tabItemsArray = data["tabItems"]?.jsonArray ?: return
+    val tabsArray = data["tabs"]?.jsonArray ?: return
 
-    val tabs = tabItemsArray.mapNotNull { tabElement ->
+    val tabs = tabsArray.mapNotNull { tabElement ->
         val tabObj = tabElement.jsonObject
 
         // Parse title (can be literal or path)

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/TextWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/TextWidget.kt
@@ -33,15 +33,15 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Text widget that displays a string with optional markdown formatting.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - text (required): Text content to display
- * - usageHint (optional): h1, h2, h3, h4, h5, caption, body
+ * - variant (optional): h1, h2, h3, h4, h5, caption, body
  *
  * JSON Schema:
  * ```json
  * {
- *   "text": {"literalString": "Hello"} | {"path": "/user/name"},
- *   "usageHint": {"literalString": "h1"} | {"literalString": "body"}
+ *   "text": "Hello" | {"path": "/user/name"},
+ *   "variant": "h1" | "body"
  * }
  * ```
  */
@@ -51,7 +51,7 @@ val TextWidget = CatalogItem(
     TextWidgetContent(data = data, dataContext = dataContext)
 }
 
-private val EXPECTED_PROPERTIES = setOf("text", "usageHint")
+private val EXPECTED_PROPERTIES = setOf("text", "variant")
 
 @Composable
 private fun TextWidgetContent(
@@ -61,7 +61,7 @@ private fun TextWidgetContent(
     PropertyValidation.warnUnexpectedProperties("Text", data, EXPECTED_PROPERTIES)
 
     val textRef = DataReferenceParser.parseString(data["text"])
-    val usageHint = data["usageHint"]?.let {
+    val variantRef = data["variant"]?.let {
         DataReferenceParser.parseString(it)
     }
 
@@ -71,13 +71,13 @@ private fun TextWidgetContent(
         else -> ""
     }
 
-    val hint = when (usageHint) {
-        is LiteralString -> usageHint.value
-        is PathString -> dataContext.getString(usageHint.path)
+    val variant = when (variantRef) {
+        is LiteralString -> variantRef.value
+        is PathString -> dataContext.getString(variantRef.path)
         else -> null
     }
 
-    val style = getTextStyle(hint)
+    val style = getTextStyle(variant)
     val annotatedString = parseBasicMarkdown(text)
 
     Text(
@@ -87,14 +87,14 @@ private fun TextWidgetContent(
 }
 
 /**
- * Maps A2UI usageHint values to Compose TextStyle.
+ * Maps A2UI variant values to Compose TextStyle.
  *
- * Valid usageHint values per A2UI v0.8 spec:
+ * Valid variant values per A2UI v0.9 spec:
  * h1, h2, h3, h4, h5, caption, body
  */
 @Composable
-private fun getTextStyle(usageHint: String?): TextStyle {
-    return when (usageHint?.lowercase()) {
+private fun getTextStyle(variant: String?): TextStyle {
+    return when (variant?.lowercase()) {
         "h1" -> MaterialTheme.typography.headlineLarge
         "h2" -> MaterialTheme.typography.headlineMedium
         "h3" -> MaterialTheme.typography.headlineSmall

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/VideoWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/VideoWidget.kt
@@ -40,13 +40,13 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Video widget for displaying video content.
  *
- * A2UI Protocol Properties (v0.8):
+ * A2UI Protocol Properties (v0.9):
  * - url (required): URL of the video source
  *
  * JSON Schema:
  * ```json
  * {
- *   "url": {"literalString": "https://example.com/video.mp4"}
+ *   "url": "https://example.com/video.mp4"
  * }
  * ```
  *

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIClientCapabilities.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIClientCapabilities.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Serializable
  * {
  *   "a2uiClientCapabilities": {
  *     "supportedCatalogIds": [
- *       "https://github.com/google/A2UI/blob/main/specification/0.8/json/standard_catalog_definition.json"
+ *       "https://github.com/google/A2UI/blob/main/specification/v0_9/json/standard_catalog.json"
  *     ]
  *   }
  * }
@@ -59,7 +59,7 @@ data class A2UIClientCapabilities(
 )
 
 /**
- * Creates [A2UIClientCapabilities] for the standard A2UI v0.8 catalog.
+ * Creates [A2UIClientCapabilities] for the standard A2UI v0.9 catalog.
  *
  * This is the most common configuration for clients that implement the
  * 18 standard widgets defined in the A2UI specification.

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt
@@ -17,52 +17,32 @@
 package com.contextable.a2ui4k.extension
 
 /**
- * Constants for the A2UI protocol.
+ * Constants for the A2UI v0.9 protocol.
  *
  * A2UI is a protocol for agents to render rich user interfaces. These constants
- * define the standard identifiers used in A2UI v0.8.
- *
- * ## Usage
- *
- * ```kotlin
- * // Check if a catalog is the standard catalog
- * if (catalogId == A2UIExtension.STANDARD_CATALOG_URI) {
- *     // Use CoreCatalog
- * }
- *
- * // Check MIME type of response data
- * if (part.mimeType == A2UIExtension.MIME_TYPE) {
- *     // Process as A2UI operation
- * }
- * ```
+ * define the standard identifiers used in A2UI v0.9.
  *
  * @see A2UIExtensionParams
  * @see A2UIClientCapabilities
  */
 object A2UIExtension {
     /**
-     * The URI identifying the A2UI v0.8 extension.
-     *
-     * This URI is used to identify A2UI capability in extension negotiations.
+     * The URI identifying the A2UI v0.9 extension.
      */
-    const val URI_V08 = "https://a2ui.org/a2a-extension/a2ui/v0.8"
+    const val URI_V09 = "https://a2ui.org/a2a-extension/a2ui/v0.9"
 
     /**
-     * The URI of the standard A2UI v0.8 component catalog definition.
-     *
-     * This catalog includes the 18 standard widgets: Text, Button, Image,
-     * Icon, Divider, Video, AudioPlayer, Column, Row, List, Card, Tabs,
-     * Modal, TextField, CheckBox, Slider, MultipleChoice, and DateTimeInput.
-     *
-     * @see com.contextable.a2ui4k.catalog.CoreCatalog
+     * The URI of the standard A2UI v0.9 component catalog definition.
      */
-    const val STANDARD_CATALOG_URI = "https://github.com/google/A2UI/blob/main/specification/0.8/json/standard_catalog_definition.json"
+    const val STANDARD_CATALOG_URI = "https://github.com/google/A2UI/blob/main/specification/v0_9/json/standard_catalog.json"
 
     /**
      * The MIME type for A2UI data in message parts.
-     *
-     * When A2UI operations are transmitted as data parts in messages,
-     * this MIME type identifies the content as A2UI JSON.
      */
     const val MIME_TYPE = "application/json+a2ui"
+
+    /**
+     * The protocol version string.
+     */
+    const val PROTOCOL_VERSION = "v0.9"
 }

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtensionParams.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtensionParams.kt
@@ -29,8 +29,8 @@ import kotlinx.serialization.Serializable
  * ```json
  * {
  *   "supportedCatalogIds": [
- *     "https://github.com/google/A2UI/blob/main/specification/0.8/json/standard_catalog_definition.json",
- *     "https://my-company.com/a2ui/v0.8/my_custom_catalog.json"
+ *     "https://github.com/google/A2UI/blob/main/specification/v0_9/json/standard_catalog.json",
+ *     "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
  *   ],
  *   "acceptsInlineCatalogs": true
  * }

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/function/FunctionEvaluator.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/function/FunctionEvaluator.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2025 Contextable LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.contextable.a2ui4k.function
+
+import com.contextable.a2ui4k.model.DataContext
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Evaluates A2UI v0.9 standard functions.
+ *
+ * The A2UI v0.9 protocol defines a set of named functions that can be
+ * referenced in FunctionCall objects. These functions handle validation,
+ * formatting, logic operations, and actions.
+ *
+ * ## Standard Functions
+ *
+ * **Validation:** required, regex, length, numeric, email
+ * **Formatting:** formatString, formatNumber, formatCurrency, formatDate, pluralize
+ * **Logic:** and, or, not
+ * **Actions:** openUrl
+ */
+object FunctionEvaluator {
+
+    /**
+     * Evaluates a function call and returns the result.
+     *
+     * @param call The function name
+     * @param args The function arguments (may contain dynamic values)
+     * @param dataContext The data context for resolving path references in args
+     * @return The function result, or null if the function is unknown or evaluation fails
+     */
+    fun evaluate(call: String, args: JsonObject?, dataContext: DataContext): JsonElement? {
+        return when (call) {
+            // Validation functions
+            "required" -> evaluateRequired(args, dataContext)
+            "regex" -> evaluateRegex(args, dataContext)
+            "length" -> evaluateLength(args, dataContext)
+            "numeric" -> evaluateNumeric(args, dataContext)
+            "email" -> evaluateEmail(args, dataContext)
+
+            // Logic functions
+            "and" -> evaluateAnd(args, dataContext)
+            "or" -> evaluateOr(args, dataContext)
+            "not" -> evaluateNot(args, dataContext)
+
+            // Formatting functions
+            "formatString" -> evaluateFormatString(args, dataContext)
+            "formatNumber" -> evaluateFormatNumber(args, dataContext)
+            "formatCurrency" -> evaluateFormatCurrency(args, dataContext)
+            "formatDate" -> evaluateFormatDate(args, dataContext)
+            "pluralize" -> evaluatePluralize(args, dataContext)
+
+            // Action functions
+            "openUrl" -> null // openUrl is an action, not a value-returning function
+
+            else -> {
+                println("Info: Unknown function '$call'")
+                null
+            }
+        }
+    }
+
+    /**
+     * Evaluates a function call that returns a boolean result.
+     */
+    fun evaluateBoolean(call: String, args: JsonObject?, dataContext: DataContext): Boolean? {
+        val result = evaluate(call, args, dataContext) ?: return null
+        return (result as? JsonPrimitive)?.booleanOrNull
+    }
+
+    /**
+     * Evaluates a function call that returns a string result.
+     */
+    fun evaluateString(call: String, args: JsonObject?, dataContext: DataContext): String? {
+        val result = evaluate(call, args, dataContext) ?: return null
+        return (result as? JsonPrimitive)?.contentOrNull
+    }
+
+    // --- Validation Functions ---
+
+    private fun evaluateRequired(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArg(args, "value", dataContext)
+        val isValid = when {
+            value == null -> false
+            value is JsonPrimitive && value.contentOrNull.isNullOrBlank() -> false
+            else -> true
+        }
+        return JsonPrimitive(isValid)
+    }
+
+    private fun evaluateRegex(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgString(args, "value", dataContext) ?: return JsonPrimitive(false)
+        val pattern = resolveArgString(args, "pattern", dataContext) ?: return JsonPrimitive(false)
+        return try {
+            JsonPrimitive(Regex(pattern).matches(value))
+        } catch (e: Exception) {
+            JsonPrimitive(false)
+        }
+    }
+
+    private fun evaluateLength(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgString(args, "value", dataContext) ?: return JsonPrimitive(false)
+        val min = resolveArgNumber(args, "min", dataContext)?.toInt()
+        val max = resolveArgNumber(args, "max", dataContext)?.toInt()
+
+        val len = value.length
+        val minOk = min == null || len >= min
+        val maxOk = max == null || len <= max
+        return JsonPrimitive(minOk && maxOk)
+    }
+
+    private fun evaluateNumeric(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgNumber(args, "value", dataContext) ?: return JsonPrimitive(false)
+        val min = resolveArgNumber(args, "min", dataContext)
+        val max = resolveArgNumber(args, "max", dataContext)
+
+        val minOk = min == null || value >= min
+        val maxOk = max == null || value <= max
+        return JsonPrimitive(minOk && maxOk)
+    }
+
+    private fun evaluateEmail(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgString(args, "value", dataContext) ?: return JsonPrimitive(false)
+        // Simple email validation
+        val emailRegex = Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+        return JsonPrimitive(emailRegex.matches(value))
+    }
+
+    // --- Logic Functions ---
+
+    private fun evaluateAnd(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val conditions = args?.get("conditions")
+        if (conditions is kotlinx.serialization.json.JsonArray) {
+            return JsonPrimitive(conditions.all { elem ->
+                when {
+                    elem is JsonPrimitive -> elem.booleanOrNull ?: false
+                    elem is JsonObject && elem.containsKey("call") -> {
+                        val innerCall = elem["call"]?.jsonPrimitive?.contentOrNull ?: return@all false
+                        val innerArgs = elem["args"] as? JsonObject
+                        evaluateBoolean(innerCall, innerArgs, dataContext) ?: false
+                    }
+                    else -> false
+                }
+            })
+        }
+        return JsonPrimitive(false)
+    }
+
+    private fun evaluateOr(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val conditions = args?.get("conditions")
+        if (conditions is kotlinx.serialization.json.JsonArray) {
+            return JsonPrimitive(conditions.any { elem ->
+                when {
+                    elem is JsonPrimitive -> elem.booleanOrNull ?: false
+                    elem is JsonObject && elem.containsKey("call") -> {
+                        val innerCall = elem["call"]?.jsonPrimitive?.contentOrNull ?: return@any false
+                        val innerArgs = elem["args"] as? JsonObject
+                        evaluateBoolean(innerCall, innerArgs, dataContext) ?: false
+                    }
+                    else -> false
+                }
+            })
+        }
+        return JsonPrimitive(false)
+    }
+
+    private fun evaluateNot(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val condition = args?.get("condition")
+        val value = when {
+            condition is JsonPrimitive -> condition.booleanOrNull ?: false
+            condition is JsonObject && condition.containsKey("call") -> {
+                val innerCall = condition["call"]?.jsonPrimitive?.contentOrNull ?: return JsonPrimitive(true)
+                val innerArgs = condition["args"] as? JsonObject
+                evaluateBoolean(innerCall, innerArgs, dataContext) ?: false
+            }
+            else -> false
+        }
+        return JsonPrimitive(!value)
+    }
+
+    // --- Formatting Functions ---
+
+    private fun evaluateFormatString(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val template = resolveArgString(args, "template", dataContext) ?: return JsonPrimitive("")
+
+        // Replace ${expression} patterns with resolved values
+        val result = Regex("\\$\\{([^}]+)\\}").replace(template) { match ->
+            val expression = match.groupValues[1].trim()
+            // Check if it's a path reference (starts with / or is a relative path)
+            val resolved = dataContext.getString(expression)
+                ?: dataContext.getNumber(expression)?.toString()
+                ?: dataContext.getBoolean(expression)?.toString()
+                ?: ""
+            resolved
+        }
+        return JsonPrimitive(result)
+    }
+
+    private fun evaluateFormatNumber(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgNumber(args, "value", dataContext) ?: return JsonPrimitive("")
+        val minimumFractionDigits = resolveArgNumber(args, "minimumFractionDigits", dataContext)?.toInt() ?: 0
+        val maximumFractionDigits = resolveArgNumber(args, "maximumFractionDigits", dataContext)?.toInt() ?: 3
+        val useGrouping = resolveArgBoolean(args, "useGrouping", dataContext) ?: true
+
+        // Basic number formatting
+        val formatted = if (maximumFractionDigits == 0 && value == value.toLong().toDouble()) {
+            value.toLong().toString()
+        } else {
+            val str = value.toBigDecimal().toPlainString()
+            val parts = str.split(".")
+            val intPart = if (useGrouping) addThousandsSeparator(parts[0]) else parts[0]
+            if (parts.size > 1) {
+                val fracPart = parts[1].take(maximumFractionDigits).padEnd(minimumFractionDigits, '0')
+                if (fracPart.isEmpty()) intPart else "$intPart.$fracPart"
+            } else {
+                if (minimumFractionDigits > 0) "$intPart.${"0".repeat(minimumFractionDigits)}"
+                else intPart
+            }
+        }
+        return JsonPrimitive(formatted)
+    }
+
+    private fun evaluateFormatCurrency(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgNumber(args, "value", dataContext) ?: return JsonPrimitive("")
+        val currency = resolveArgString(args, "currency", dataContext) ?: "USD"
+
+        val symbol = when (currency.uppercase()) {
+            "USD" -> "$"
+            "EUR" -> "\u20AC"
+            "GBP" -> "\u00A3"
+            "JPY" -> "\u00A5"
+            else -> currency
+        }
+        val formatted = addThousandsSeparator(value.toLong().toString())
+        val cents = ((value - value.toLong()) * 100).toLong().toString().padStart(2, '0')
+        return JsonPrimitive("$symbol$formatted.$cents")
+    }
+
+    private fun evaluateFormatDate(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val value = resolveArgString(args, "value", dataContext) ?: return JsonPrimitive("")
+        // Basic pass-through for now — full Unicode TR35 format support would require
+        // a date parsing library
+        return JsonPrimitive(value)
+    }
+
+    private fun evaluatePluralize(args: JsonObject?, dataContext: DataContext): JsonElement {
+        val count = resolveArgNumber(args, "count", dataContext)?.toLong() ?: 0L
+        val other = resolveArgString(args, "other", dataContext) ?: ""
+        val one = resolveArgString(args, "one", dataContext)
+        val zero = resolveArgString(args, "zero", dataContext)
+
+        // Basic CLDR-like pluralization for English
+        val result = when {
+            count == 0L && zero != null -> zero
+            count == 1L && one != null -> one
+            else -> other
+        }
+        return JsonPrimitive(result)
+    }
+
+    // --- Argument Resolution Helpers ---
+
+    private fun resolveArg(args: JsonObject?, name: String, dataContext: DataContext): JsonElement? {
+        val element = args?.get(name) ?: return null
+        return when {
+            element is JsonObject && element.containsKey("path") -> {
+                val path = element["path"]?.jsonPrimitive?.contentOrNull ?: return null
+                dataContext.getString(path)?.let { JsonPrimitive(it) }
+                    ?: dataContext.getNumber(path)?.let { JsonPrimitive(it) }
+                    ?: dataContext.getBoolean(path)?.let { JsonPrimitive(it) }
+            }
+            else -> element
+        }
+    }
+
+    private fun resolveArgString(args: JsonObject?, name: String, dataContext: DataContext): String? {
+        val element = args?.get(name) ?: return null
+        return when {
+            element is JsonPrimitive -> element.contentOrNull
+            element is JsonObject && element.containsKey("path") -> {
+                val path = element["path"]?.jsonPrimitive?.contentOrNull ?: return null
+                dataContext.getString(path)
+            }
+            else -> null
+        }
+    }
+
+    private fun resolveArgNumber(args: JsonObject?, name: String, dataContext: DataContext): Double? {
+        val element = args?.get(name) ?: return null
+        return when {
+            element is JsonPrimitive -> element.doubleOrNull
+            element is JsonObject && element.containsKey("path") -> {
+                val path = element["path"]?.jsonPrimitive?.contentOrNull ?: return null
+                dataContext.getNumber(path)
+            }
+            else -> null
+        }
+    }
+
+    private fun resolveArgBoolean(args: JsonObject?, name: String, dataContext: DataContext): Boolean? {
+        val element = args?.get(name) ?: return null
+        return when {
+            element is JsonPrimitive -> element.booleanOrNull
+            element is JsonObject && element.containsKey("path") -> {
+                val path = element["path"]?.jsonPrimitive?.contentOrNull ?: return null
+                dataContext.getBoolean(path)
+            }
+            else -> null
+        }
+    }
+
+    private fun addThousandsSeparator(intPart: String): String {
+        val negative = intPart.startsWith("-")
+        val digits = if (negative) intPart.substring(1) else intPart
+        val result = digits.reversed().chunked(3).joinToString(",").reversed()
+        return if (negative) "-$result" else result
+    }
+}

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/A2UiOperation.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/A2UiOperation.kt
@@ -25,10 +25,16 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
 
 /**
- * Represents an A2UI operation that modifies the surface state.
+ * Represents an A2UI v0.9 operation that modifies the surface state.
  *
- * Operations are received via ACTIVITY_SNAPSHOT/DELTA events and processed
+ * Operations are received as streaming JSON messages and processed
  * by [SurfaceStateManager] to build [UiDefinition] instances.
+ *
+ * In v0.9, the four message types are:
+ * - `createSurface`: Initializes a surface with catalogId and optional theme
+ * - `updateComponents`: Adds or updates component definitions
+ * - `updateDataModel`: Updates data at specified path with any JSON value
+ * - `deleteSurface`: Removes a surface
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
@@ -37,27 +43,42 @@ sealed class A2UIOperation
 /**
  * Initializes a new surface for rendering.
  *
+ * In v0.9, the root component is identified by convention (component with id "root")
+ * rather than an explicit root property.
+ *
  * @property surfaceId Unique identifier for the surface
- * @property root The ID of the root component
- * @property styles Optional styling configuration for the surface
+ * @property catalogId URI identifying the component catalog to use
+ * @property theme Optional theme parameters for the surface
+ * @property sendDataModel When true, client includes full data model in A2A metadata
  */
 @Serializable
-@SerialName("beginRendering")
-data class BeginRendering(
+@SerialName("createSurface")
+data class CreateSurface(
     val surfaceId: String,
-    val root: String,
-    val styles: JsonObject? = null
+    val catalogId: String,
+    val theme: JsonObject? = null,
+    val sendDataModel: Boolean = false
 ) : A2UIOperation()
 
 /**
  * Updates components in a surface.
  *
+ * In v0.9, components use a flat discriminator format:
+ * ```json
+ * {
+ *   "id": "title",
+ *   "component": "Text",
+ *   "text": "Hello World",
+ *   "variant": "h1"
+ * }
+ * ```
+ *
  * @property surfaceId The surface to update
  * @property components List of component definitions to add or update
  */
 @Serializable
-@SerialName("surfaceUpdate")
-data class SurfaceUpdate(
+@SerialName("updateComponents")
+data class UpdateComponents(
     val surfaceId: String,
     val components: List<ComponentDef>
 ) : A2UIOperation()
@@ -65,16 +86,21 @@ data class SurfaceUpdate(
 /**
  * Updates the data model for a surface.
  *
+ * In v0.9, data updates use standard JSON values with upsert semantics:
+ * - Existing paths are updated
+ * - Non-existent paths are created
+ * - Omitting value deletes the key
+ *
  * @property surfaceId The surface whose data model to update
- * @property path JSON Pointer path in the data model
- * @property contents List of data entries to set at the path
+ * @property path JSON Pointer path (defaults to "/" for entire model)
+ * @property value The new value; omitting deletes the key
  */
 @Serializable
-@SerialName("dataModelUpdate")
-data class DataModelUpdate(
+@SerialName("updateDataModel")
+data class UpdateDataModel(
     val surfaceId: String,
-    val path: String,
-    val contents: List<DataEntry>
+    val path: String = "/",
+    val value: JsonElement? = null
 ) : A2UIOperation()
 
 /**
@@ -89,19 +115,17 @@ data class DeleteSurface(
 ) : A2UIOperation()
 
 /**
- * A component definition parsed from A2UI v0.8 protocol.
+ * A component definition in A2UI v0.9 format.
  *
- * Use [fromJson] to parse from v0.8 JSON format where the component
- * is a nested object:
+ * v0.9 uses a flat discriminator where `component` is a string type name
+ * and all properties are at the top level:
  * ```json
  * {
- *   "id": "title",
- *   "component": {
- *     "Text": {
- *       "text": { "literalString": "Hello World" },
- *       "usageHint": { "literalString": "h1" }
- *     }
- *   }
+ *   "id": "my-button",
+ *   "component": "Button",
+ *   "child": "button-text",
+ *   "variant": "primary",
+ *   "action": {"event": {"name": "submit"}}
  * }
  * ```
  */
@@ -109,27 +133,21 @@ data class DeleteSurface(
 data class ComponentDef(
     val id: String,
     val component: String,
-    /**
-     * Additional properties are captured here during deserialization.
-     * This allows the component to have arbitrary widget-specific properties.
-     */
     val properties: JsonObject = JsonObject(emptyMap()),
-    /**
-     * Optional flex weight for layout containers (at component level, not in properties).
-     */
     val weight: Int? = null
 ) {
     companion object {
         /**
          * Creates a ComponentDef from a raw JsonObject.
          *
-         * Parses v0.8 format where component is an object:
+         * Parses v0.9 flat format where component is a string discriminator
+         * and properties are at the top level:
          * ```json
          * {
          *   "id": "my-id",
-         *   "component": {
-         *     "Column": { "children": { "explicitList": ["child1"] } }
-         *   }
+         *   "component": "Column",
+         *   "children": ["child1", "child2"],
+         *   "justify": "spaceBetween"
          * }
          * ```
          */
@@ -138,67 +156,25 @@ data class ComponentDef(
                 (it as? kotlinx.serialization.json.JsonPrimitive)?.content
             } ?: error("Component missing 'id'")
 
-            val componentObj = json["component"]?.let {
-                it as? JsonObject
-            } ?: error("Component missing 'component' object")
+            val component = json["component"]?.let {
+                (it as? kotlinx.serialization.json.JsonPrimitive)?.content
+            } ?: error("Component missing 'component' string")
 
-            // v0.8: component is {"WidgetType": {props}}
-            val widgetType = componentObj.keys.firstOrNull()
-                ?: error("Component object is empty")
-            val properties = componentObj[widgetType] as? JsonObject
-                ?: JsonObject(emptyMap())
-
-            // Extract weight from top level (not inside component properties)
+            // Extract weight from top level
             val weight = json["weight"]?.let {
                 (it as? kotlinx.serialization.json.JsonPrimitive)?.intOrNull
             }
 
+            // All other properties (excluding id, component, weight) become the properties object
+            val reservedKeys = setOf("id", "component", "weight")
+            val propertyMap = json.filterKeys { it !in reservedKeys }
+
             return ComponentDef(
                 id = id,
-                component = widgetType,
-                properties = properties,
+                component = component,
+                properties = JsonObject(propertyMap),
                 weight = weight
             )
-        }
-    }
-}
-
-/**
- * A data entry for updating the data model.
- *
- * Supports multiple value types matching the A2UI protocol:
- * - valueString: String values
- * - valueNumber: Numeric values
- * - valueBool: Boolean values
- * - valueMap: Nested object (list of key-value pairs that becomes a JsonObject)
- * - valueJson: Raw JSON
- */
-@Serializable
-data class DataEntry(
-    val key: String,
-    val valueString: String? = null,
-    val valueNumber: Double? = null,
-    val valueBoolean: Boolean? = null,
-    val valueMap: List<DataEntry>? = null,
-    val valueJson: JsonElement? = null
-) {
-    /**
-     * Returns the value as a JsonElement for storage in the data model.
-     */
-    fun toJsonElement(): JsonElement {
-        return when {
-            valueString != null -> kotlinx.serialization.json.JsonPrimitive(valueString)
-            valueNumber != null -> kotlinx.serialization.json.JsonPrimitive(valueNumber)
-            valueBoolean != null -> kotlinx.serialization.json.JsonPrimitive(valueBoolean)
-            valueMap != null -> {
-                // Convert list of DataEntry to JsonObject
-                val map = valueMap.associate { entry ->
-                    entry.key to entry.toJsonElement()
-                }
-                JsonObject(map)
-            }
-            valueJson != null -> valueJson
-            else -> kotlinx.serialization.json.JsonNull
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/CatalogItem.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/CatalogItem.kt
@@ -37,8 +37,8 @@ typealias EventDispatcher = (UiEvent) -> Unit
  * the widget's configuration data, functions to build children and
  * dispatch events, and a [DataContext] for resolving path bindings.
  *
- * The A2UI v0.8 specification defines 18 standard widgets in the
- * standard_catalog_definition.json. These are implemented in [CoreCatalog].
+ * The A2UI v0.9 specification defines 18 standard widgets in the
+ * standard_catalog.json. These are implemented in [CoreCatalog].
  *
  * @property name The widget type identifier (e.g., "Text", "Column", "Button")
  * @property compose The Composable function that renders this widget

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/UiDefinition.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/UiDefinition.kt
@@ -17,21 +17,22 @@
 package com.contextable.a2ui4k.model
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
- * Represents the complete state of a UI surface in the A2UI protocol.
+ * Represents the complete state of a UI surface in the A2UI v0.9 protocol.
  *
  * A UiDefinition contains all the components that make up a surface,
- * along with metadata about which component is the root and which
- * catalog should be used for rendering.
+ * along with metadata about which catalog should be used for rendering.
  *
- * In the A2UI v0.8 protocol, UiDefinitions are built from `beginRendering`
- * and `surfaceUpdate` operations processed by [SurfaceStateManager].
+ * In v0.9, the root component is identified by convention: the component
+ * with id "root" serves as the entry point for rendering.
  *
  * @property surfaceId Unique identifier for this surface
  * @property components Map of component ID to [Component] definitions
- * @property root The ID of the root component to start rendering from
- * @property catalogId Optional identifier of the catalog to use for this surface
+ * @property catalogId Identifier of the catalog to use for this surface
+ * @property theme Optional theme parameters for the surface
+ * @property sendDataModel When true, client includes full data model in metadata
  *
  * @see Component
  * @see com.contextable.a2ui4k.state.SurfaceStateManager
@@ -41,26 +42,24 @@ import kotlinx.serialization.Serializable
 data class UiDefinition(
     val surfaceId: String,
     val components: Map<String, Component> = emptyMap(),
-    val root: String? = null,
-    val catalogId: String? = null
+    val catalogId: String? = null,
+    val theme: JsonObject? = null,
+    val sendDataModel: Boolean = false
 ) {
     /**
-     * Returns the root component if it exists.
+     * Returns the root component (component with id "root").
+     *
+     * In v0.9, the root is identified by convention rather than
+     * an explicit property.
      */
     val rootComponent: Component?
-        get() = root?.let { components[it] }
+        get() = components["root"]
 
     /**
      * Creates a copy with updated components.
      */
     fun withComponents(newComponents: Map<String, Component>): UiDefinition =
         copy(components = components + newComponents)
-
-    /**
-     * Creates a copy with the root set.
-     */
-    fun withRoot(rootId: String, catalog: String? = null): UiDefinition =
-        copy(root = rootId, catalogId = catalog ?: catalogId)
 
     companion object {
         /**

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/UiEvent.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/model/UiEvent.kt
@@ -26,12 +26,14 @@ import kotlinx.serialization.json.JsonObject
  * (button clicks, form submissions, etc.) and can be sent back
  * to the AI agent for processing.
  *
- * In the A2UI v0.8 protocol, these correspond to client-to-server messages:
- * - [UserActionEvent] maps to the `userAction` message type
- * - [DataChangeEvent] maps to the `dataChange` message type
+ * In A2UI v0.9, client-to-server messages include:
+ * - [ActionEvent] maps to the `action` message type
+ * - [DataChangeEvent] is an internal event for two-way data binding
+ * - [ValidationError] maps to the `error` message type with VALIDATION_FAILED code
  *
- * @see UserActionEvent
+ * @see ActionEvent
  * @see DataChangeEvent
+ * @see ValidationError
  */
 sealed class UiEvent {
     /**
@@ -41,27 +43,30 @@ sealed class UiEvent {
 }
 
 /**
- * A user action event triggered by interaction (e.g., button click).
+ * An action event triggered by user interaction (e.g., button click).
  *
- * Matches the A2UI ClientEvent format expected by agents:
+ * In v0.9, the client-to-server format wraps this in an `action` envelope:
  * ```json
  * {
- *   "name": "action_name",
- *   "surfaceId": "default",
- *   "sourceComponentId": "component-id:item1",
- *   "timestamp": "2025-12-17T02:00:23.936Z",
- *   "context": { ... }
+ *   "version": "v0.9",
+ *   "action": {
+ *     "name": "action_name",
+ *     "surfaceId": "default",
+ *     "sourceComponentId": "component-id",
+ *     "timestamp": "2025-12-17T02:00:23.936Z",
+ *     "context": { "key": "value" }
+ *   }
  * }
  * ```
  *
- * @property name The action identifier (at root level, not nested)
+ * @property name The action identifier
  * @property surfaceId The surface where the action occurred
  * @property sourceComponentId The component ID with optional template item suffix
  * @property timestamp ISO8601 timestamp of when the event occurred
- * @property context Resolved context data from action.context bindings
+ * @property context Resolved context data from action.event.context
  */
 @Serializable
-data class UserActionEvent(
+data class ActionEvent(
     val name: String,
     override val surfaceId: String,
     val sourceComponentId: String,
@@ -72,6 +77,10 @@ data class UserActionEvent(
 /**
  * A data change event when the user modifies a bound value.
  *
+ * This is an internal client-side event used for two-way data binding.
+ * Input widgets emit this when the user changes a form value, allowing
+ * the application to update the data model accordingly.
+ *
  * @property surfaceId The surface where the change occurred
  * @property path The data model path that was modified
  * @property value The new value
@@ -81,4 +90,33 @@ data class DataChangeEvent(
     override val surfaceId: String,
     val path: String,
     val value: String
+) : UiEvent()
+
+/**
+ * A validation error sent from client to server.
+ *
+ * In v0.9, validation errors follow a structured format:
+ * ```json
+ * {
+ *   "version": "v0.9",
+ *   "error": {
+ *     "code": "VALIDATION_FAILED",
+ *     "surfaceId": "surface-1",
+ *     "path": "/components/0/text",
+ *     "message": "Required field missing"
+ *   }
+ * }
+ * ```
+ *
+ * @property code Error code (e.g., "VALIDATION_FAILED")
+ * @property surfaceId The surface where the error occurred
+ * @property path JSON Pointer to the problematic field
+ * @property message Human-readable error description
+ */
+@Serializable
+data class ValidationError(
+    val code: String = "VALIDATION_FAILED",
+    override val surfaceId: String,
+    val path: String,
+    val message: String
 ) : UiEvent()

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt
@@ -46,14 +46,17 @@ val LocalUiDefinition = compositionLocalOf<UiDefinition?> { null }
  * using widgets from the provided [Catalog]. User interactions are reported
  * via the onEvent callback as [UiEvent] instances.
  *
- * This composable implements the rendering side of the A2UI v0.8 protocol.
+ * This composable implements the rendering side of the A2UI v0.9 protocol.
  * It processes component definitions and resolves data bindings reactively.
+ *
+ * In v0.9, the root component is identified by convention: the component
+ * with id "root" serves as the entry point for rendering.
  *
  * @param definition The UI definition containing the component tree to render
  * @param modifier Modifier for the surface container
  * @param dataModel The data model for resolving path bindings (defaults to a new instance)
  * @param catalog The widget catalog to use for rendering
- * @param onEvent Callback for user interaction events ([UserActionEvent], [DataChangeEvent])
+ * @param onEvent Callback for user interaction events ([ActionEvent], [ValidationError])
  *
  * @see UiDefinition
  * @see DataModel
@@ -76,10 +79,11 @@ fun A2UISurface(
 
     CompositionLocalProvider(LocalUiDefinition provides definition) {
         Box(modifier = modifier) {
-            val rootId = definition.root
-            if (rootId != null) {
+            // v0.9: root component is identified by convention (id = "root")
+            val rootComponent = definition.rootComponent
+            if (rootComponent != null) {
                 ComponentBuilder(
-                    componentId = rootId,
+                    componentId = "root",
                     definition = definition,
                     catalog = catalog,
                     dataContext = dataContext,
@@ -122,11 +126,6 @@ internal fun ComponentBuilder(
 
     val widgetType = component.widgetType
     val widgetData = component.widgetData
-
-    if (widgetType == null || widgetData == null) {
-        InvalidComponent(componentId)
-        return
-    }
 
     val catalogItem = catalog[widgetType]
     if (catalogItem == null) {

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/util/PropertyValidation.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/util/PropertyValidation.kt
@@ -19,7 +19,7 @@ package com.contextable.a2ui4k.util
 import kotlinx.serialization.json.JsonObject
 
 /**
- * Utility for validating A2UI component properties against the v0.8 specification.
+ * Utility for validating A2UI component properties against the v0.9 specification.
  *
  * Logs info-level warnings for any unexpected properties encountered during parsing.
  * This helps identify JSON that doesn't conform to the official A2UI protocol.

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/extension/A2UIClientCapabilitiesTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/extension/A2UIClientCapabilitiesTest.kt
@@ -100,11 +100,11 @@ class A2UIClientCapabilitiesTest {
     @Test
     fun `A2UIExtension constants are correct`() {
         assertEquals(
-            "https://a2ui.org/a2a-extension/a2ui/v0.8",
-            A2UIExtension.URI_V08
+            "https://a2ui.org/a2a-extension/a2ui/v0.9",
+            A2UIExtension.URI_V09
         )
         assertEquals(
-            "https://github.com/google/A2UI/blob/main/specification/0.8/json/standard_catalog_definition.json",
+            "https://github.com/google/A2UI/blob/main/specification/v0_9/json/standard_catalog.json",
             A2UIExtension.STANDARD_CATALOG_URI
         )
         assertEquals(
@@ -120,6 +120,6 @@ class A2UIClientCapabilitiesTest {
 
         // Should produce JSON that can be included in message metadata
         assertTrue(serialized.contains("\"supportedCatalogIds\""))
-        assertTrue(serialized.contains("standard_catalog_definition.json"))
+        assertTrue(serialized.contains("standard_catalog.json"))
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/AudioPlayerWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/AudioPlayerWidgetTest.kt
@@ -26,19 +26,19 @@ import kotlin.test.assertNull
 /**
  * Tests for AudioPlayer widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - url (optional): URL of the audio source
- * - description (optional): Accessibility description / title
+ * A2UI Spec properties (v0.9):
+ * - url (optional): URL of the audio source as plain string or path binding
+ * - description (optional): Accessibility description / title as plain string or path binding
  */
 class AudioPlayerWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts url literalString`() {
+    fun `parseString extracts url literal`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://example.com/audio.mp3"}
+                "url": "https://example.com/audio.mp3"
             }
         """.trimIndent()
 
@@ -65,11 +65,11 @@ class AudioPlayerWidgetTest {
     }
 
     @Test
-    fun `parseString extracts description literalString`() {
+    fun `parseString extracts description literal`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://example.com/episode.mp3"},
-                "description": {"literalString": "Episode 42: Introduction to A2UI"}
+                "url": "https://example.com/episode.mp3",
+                "description": "Episode 42: Introduction to A2UI"
             }
         """.trimIndent()
 
@@ -100,8 +100,8 @@ class AudioPlayerWidgetTest {
     fun `complete AudioPlayer with url and description`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://cdn.example.com/podcast/ep1.mp3"},
-                "description": {"literalString": "Welcome to Our Podcast"}
+                "url": "https://cdn.example.com/podcast/ep1.mp3",
+                "description": "Welcome to Our Podcast"
             }
         """.trimIndent()
 
@@ -128,7 +128,7 @@ class AudioPlayerWidgetTest {
         val extensions = listOf("mp3", "wav", "ogg", "m4a", "aac", "flac")
 
         extensions.forEach { ext ->
-            val jsonStr = """{"url": {"literalString": "https://example.com/audio.$ext"}}"""
+            val jsonStr = """{"url": "https://example.com/audio.$ext"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
             val urlRef = DataReferenceParser.parseString(data["url"])
 
@@ -141,7 +141,7 @@ class AudioPlayerWidgetTest {
     fun `AudioPlayer with only description`() {
         val jsonStr = """
             {
-                "description": {"literalString": "Background Music"}
+                "description": "Background Music"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/CardWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/CardWidgetTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertNotNull
 /**
  * Tests for CardWidget JSON parsing.
  *
- * The Card widget in A2UI:
+ * The Card widget in A2UI v0.9:
  * - Takes a `child` property referencing another component
  * - Applies internal padding (8dp) around the child (matching A2UI protocol)
  * - Uses surface color from the theme

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/CheckBoxWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/CheckBoxWidgetTest.kt
@@ -25,9 +25,9 @@ import kotlin.test.assertNotNull
 /**
  * Tests for CheckBox widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
+ * A2UI Spec properties (v0.9):
  * - value (required): Path binding for boolean state
- * - label (optional): Label text as literalString or path
+ * - label (optional): Label text as plain string or path binding
  */
 class CheckBoxWidgetTest {
 
@@ -49,11 +49,11 @@ class CheckBoxWidgetTest {
     }
 
     @Test
-    fun `parseString extracts label literalString`() {
+    fun `parseString extracts label literal`() {
         val jsonStr = """
             {
                 "value": {"path": "/agreed"},
-                "label": {"literalString": "I agree to the terms"}
+                "label": "I agree to the terms"
             }
         """.trimIndent()
 
@@ -85,7 +85,7 @@ class CheckBoxWidgetTest {
         val jsonStr = """
             {
                 "value": {"path": "/form/newsletter"},
-                "label": {"literalString": "Subscribe to newsletter"}
+                "label": "Subscribe to newsletter"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ClientEventFormatTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ClientEventFormatTest.kt
@@ -27,24 +27,27 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * Tests for A2UI ClientEvent format.
+ * Tests for A2UI v0.9 ClientEvent format.
  *
- * Per the A2UI protocol, ClientEvents sent to the agent must have this structure:
+ * Per the A2UI v0.9 protocol, ClientEvents sent to the agent must have this structure:
  * ```json
  * {
- *   "name": "action_name",
- *   "surfaceId": "default",
- *   "sourceComponentId": "component-id:item1",
- *   "timestamp": "2025-12-17T02:00:23.936Z",
- *   "context": { "key": "value", ... }
+ *   "version": "v0.9",
+ *   "action": {
+ *     "name": "action_name",
+ *     "surfaceId": "default",
+ *     "sourceComponentId": "component-id:item1",
+ *     "timestamp": "2025-12-17T02:00:23.936Z",
+ *     "context": { "key": "value", ... }
+ *   }
  * }
  * ```
  */
 class ClientEventFormatTest {
 
     @Test
-    fun `UserActionEvent has name at root level`() {
-        val event = UserActionEvent(
+    fun `ActionEvent has name at root level`() {
+        val event = ActionEvent(
             name = "book_restaurant",
             surfaceId = "default",
             sourceComponentId = "template-book-button:item1",
@@ -56,8 +59,8 @@ class ClientEventFormatTest {
     }
 
     @Test
-    fun `UserActionEvent has sourceComponentId with item suffix`() {
-        val event = UserActionEvent(
+    fun `ActionEvent has sourceComponentId with item suffix`() {
+        val event = ActionEvent(
             name = "book_restaurant",
             surfaceId = "default",
             sourceComponentId = "template-book-button:item1",
@@ -70,8 +73,8 @@ class ClientEventFormatTest {
     }
 
     @Test
-    fun `UserActionEvent has timestamp in ISO8601 format`() {
-        val event = UserActionEvent(
+    fun `ActionEvent has timestamp in ISO8601 format`() {
+        val event = ActionEvent(
             name = "submit_form",
             surfaceId = "default",
             sourceComponentId = "submit-button",
@@ -83,14 +86,14 @@ class ClientEventFormatTest {
     }
 
     @Test
-    fun `UserActionEvent context contains resolved data`() {
+    fun `ActionEvent context contains resolved data`() {
         val context = buildJsonObject {
             put("restaurantName", "Xi'an Famous Foods")
             put("imageUrl", "http://localhost:10002/static/food.jpeg")
             put("address", "81 St Marks Pl, New York, NY 10003")
         }
 
-        val event = UserActionEvent(
+        val event = ActionEvent(
             name = "book_restaurant",
             surfaceId = "default",
             sourceComponentId = "template-book-button:item1",
@@ -103,8 +106,8 @@ class ClientEventFormatTest {
     }
 
     @Test
-    fun `UserActionEvent surfaceId should not be empty`() {
-        val event = UserActionEvent(
+    fun `ActionEvent surfaceId should not be empty`() {
+        val event = ActionEvent(
             name = "click",
             surfaceId = "default",
             sourceComponentId = "my-button",

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ComponentDefTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ComponentDefTest.kt
@@ -26,9 +26,9 @@ import kotlin.test.assertNull
 /**
  * Tests for ComponentDef parsing from JSON.
  *
- * These tests ensure that component definitions are correctly parsed,
- * including top-level properties like 'weight' that exist alongside
- * the nested component properties.
+ * These tests ensure that component definitions are correctly parsed
+ * in v0.9 flat format where 'component' is a string discriminator
+ * and properties are at the top level.
  */
 class ComponentDefTest {
 
@@ -39,9 +39,8 @@ class ComponentDefTest {
         val jsonStr = """
             {
                 "id": "my-button",
-                "component": {
-                    "Button": { "child": "button-text" }
-                }
+                "component": "Button",
+                "child": "button-text"
             }
         """.trimIndent()
 
@@ -58,9 +57,8 @@ class ComponentDefTest {
             {
                 "id": "template-image",
                 "weight": 1,
-                "component": {
-                    "Image": { "url": { "path": "imageUrl" } }
-                }
+                "component": "Image",
+                "url": {"path": "imageUrl"}
             }
         """.trimIndent()
 
@@ -78,9 +76,8 @@ class ComponentDefTest {
             {
                 "id": "card-details",
                 "weight": 2,
-                "component": {
-                    "Column": { "children": { "explicitList": ["title", "subtitle"] } }
-                }
+                "component": "Column",
+                "children": ["title", "subtitle"]
             }
         """.trimIndent()
 
@@ -97,9 +94,8 @@ class ComponentDefTest {
         val jsonStr = """
             {
                 "id": "simple-text",
-                "component": {
-                    "Text": { "text": { "literalString": "Hello" } }
-                }
+                "component": "Text",
+                "text": "Hello"
             }
         """.trimIndent()
 
@@ -116,12 +112,9 @@ class ComponentDefTest {
         val jsonStr = """
             {
                 "id": "my-text",
-                "component": {
-                    "Text": {
-                        "text": { "literalString": "Hello World" },
-                        "usageHint": { "literalString": "h1" }
-                    }
-                }
+                "component": "Text",
+                "text": "Hello World",
+                "variant": "h1"
             }
         """.trimIndent()
 
@@ -131,7 +124,7 @@ class ComponentDefTest {
         assertEquals("my-text", def.id)
         assertEquals("Text", def.component)
         assertNotNull(def.properties["text"])
-        assertNotNull(def.properties["usageHint"])
+        assertNotNull(def.properties["variant"])
     }
 
     @Test
@@ -140,9 +133,8 @@ class ComponentDefTest {
             {
                 "id": "weighted-image",
                 "weight": 3,
-                "component": {
-                    "Image": { "url": { "literalString": "https://example.com/img.jpg" } }
-                }
+                "component": "Image",
+                "url": "https://example.com/img.jpg"
             }
         """.trimIndent()
 
@@ -160,9 +152,8 @@ class ComponentDefTest {
         val jsonStr = """
             {
                 "id": "no-weight",
-                "component": {
-                    "Text": { "text": { "literalString": "No weight" } }
-                }
+                "component": "Text",
+                "text": "No weight"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ComponentTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ComponentTest.kt
@@ -16,6 +16,7 @@
 
 package com.contextable.a2ui4k.model
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
@@ -24,36 +25,28 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 /**
- * Tests for Component class - represents a UI component in A2UI v0.8 format.
+ * Tests for Component class - represents a UI component in A2UI v0.9 format.
  */
 class ComponentTest {
 
     @Test
-    fun `widgetType returns first key from componentProperties`() {
+    fun `widgetType returns componentType`() {
         val component = Component(
             id = "test",
-            componentProperties = mapOf("Text" to JsonObject(emptyMap()))
+            componentType = "Text",
+            properties = JsonObject(emptyMap())
         )
 
         assertEquals("Text", component.widgetType)
     }
 
     @Test
-    fun `widgetType returns null when componentProperties empty`() {
-        val component = Component(
-            id = "test",
-            componentProperties = emptyMap()
-        )
-
-        assertNull(component.widgetType)
-    }
-
-    @Test
-    fun `widgetData returns first value from componentProperties`() {
+    fun `widgetData returns properties`() {
         val data = JsonObject(mapOf("text" to JsonPrimitive("Hello")))
         val component = Component(
             id = "test",
-            componentProperties = mapOf("Text" to data)
+            componentType = "Text",
+            properties = data
         )
 
         assertNotNull(component.widgetData)
@@ -61,13 +54,13 @@ class ComponentTest {
     }
 
     @Test
-    fun `widgetData returns null when componentProperties empty`() {
+    fun `widgetData returns empty JsonObject when no properties`() {
         val component = Component(
             id = "test",
-            componentProperties = emptyMap()
+            componentType = "Text"
         )
 
-        assertNull(component.widgetData)
+        assertEquals(JsonObject(emptyMap()), component.widgetData)
     }
 
     @Test
@@ -97,7 +90,7 @@ class ComponentTest {
             id = "img1",
             component = "Image",
             properties = JsonObject(mapOf(
-                "url" to JsonObject(mapOf("literalString" to JsonPrimitive("https://example.com/img.jpg")))
+                "url" to JsonPrimitive("https://example.com/img.jpg")
             )),
             weight = 1
         )
@@ -113,8 +106,8 @@ class ComponentTest {
     @Test
     fun `fromComponentDef preserves all properties`() {
         val props = JsonObject(mapOf(
-            "text" to JsonObject(mapOf("literalString" to JsonPrimitive("Hello"))),
-            "usageHint" to JsonObject(mapOf("literalString" to JsonPrimitive("h1")))
+            "text" to JsonPrimitive("Hello"),
+            "variant" to JsonPrimitive("h1")
         ))
 
         val def = ComponentDef(
@@ -146,10 +139,8 @@ class ComponentTest {
     fun `Component preserves complex widget data`() {
         val complexData = JsonObject(mapOf(
             "children" to JsonObject(mapOf(
-                "template" to JsonObject(mapOf(
-                    "componentId" to JsonPrimitive("item-template"),
-                    "dataBinding" to JsonPrimitive("/items")
-                ))
+                "componentId" to JsonPrimitive("item-template"),
+                "path" to JsonPrimitive("/items")
             )),
             "direction" to JsonPrimitive("vertical")
         ))

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/DateTimeInputWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/DateTimeInputWidgetTest.kt
@@ -27,10 +27,10 @@ import kotlin.test.assertTrue
 /**
  * Tests for DateTimeInput widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
+ * A2UI Spec properties (v0.9):
  * - value (required): Path binding for the date/time value
- * - enableDate (optional): Boolean to enable date picker
- * - enableTime (optional): Boolean to enable time picker
+ * - enableDate (optional): Boolean to enable date picker (plain boolean in v0.9)
+ * - enableTime (optional): Boolean to enable time picker (plain boolean in v0.9)
  */
 class DateTimeInputWidgetTest {
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/DividerWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/DividerWidgetTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertNull
 /**
  * Tests for Divider widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
+ * A2UI Spec properties (v0.9):
  * - axis (optional): "horizontal" or "vertical" (default: horizontal)
  */
 class DividerWidgetTest {

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/IconWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/IconWidgetTest.kt
@@ -26,18 +26,18 @@ import kotlin.test.assertNull
 /**
  * Tests for Icon widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - name (required): Icon name as literalString or path
+ * A2UI Spec properties (v0.9):
+ * - name (required): Icon name as plain string or path binding
  */
 class IconWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts name literalString`() {
+    fun `parseString extracts name literal`() {
         val jsonStr = """
             {
-                "name": {"literalString": "home"}
+                "name": "home"
             }
         """.trimIndent()
 
@@ -71,7 +71,7 @@ class IconWidgetTest {
         )
 
         iconNames.forEach { iconName ->
-            val jsonStr = """{"name": {"literalString": "$iconName"}}"""
+            val jsonStr = """{"name": "$iconName"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
             val nameRef = DataReferenceParser.parseString(data["name"])
 
@@ -84,7 +84,7 @@ class IconWidgetTest {
     fun `icon with camelCase name`() {
         val jsonStr = """
             {
-                "name": {"literalString": "playArrow"}
+                "name": "playArrow"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ImageWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ImageWidgetTest.kt
@@ -26,20 +26,20 @@ import kotlin.test.assertNull
 /**
  * Tests for Image widget JSON parsing.
  *
- * A2UI Spec properties:
- * - url (required): Image URL as literalString or path
+ * A2UI Spec properties (v0.9):
+ * - url (required): Image URL as plain string or path binding
  * - fit (optional): contain, cover, fill, none, scale-down
- * - usageHint (optional): icon, avatar, smallFeature, mediumFeature, largeFeature, header
+ * - variant (optional): icon, avatar, smallFeature, mediumFeature, largeFeature, header
  */
 class ImageWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts url literalString`() {
+    fun `parseString extracts url literal`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://example.com/image.jpg"}
+                "url": "https://example.com/image.jpg"
             }
         """.trimIndent()
 
@@ -80,16 +80,16 @@ class ImageWidgetTest {
     }
 
     @Test
-    fun `all usageHint values are valid`() {
-        val hints = listOf("icon", "avatar", "smallFeature", "mediumFeature", "largeFeature", "header")
+    fun `all variant values are valid`() {
+        val variants = listOf("icon", "avatar", "smallFeature", "mediumFeature", "largeFeature", "header")
 
-        hints.forEach { hint ->
-            val jsonStr = """{"usageHint": "$hint"}"""
+        variants.forEach { variant ->
+            val jsonStr = """{"variant": "$variant"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
-            val ref = DataReferenceParser.parseString(data["usageHint"])
+            val ref = DataReferenceParser.parseString(data["variant"])
 
-            assertNotNull(ref, "usageHint '$hint' should parse")
-            assertEquals(hint, (ref as LiteralString).value)
+            assertNotNull(ref, "variant '$variant' should parse")
+            assertEquals(variant, (ref as LiteralString).value)
         }
     }
 
@@ -99,7 +99,7 @@ class ImageWidgetTest {
             {
                 "url": {"path": "/user/avatar"},
                 "fit": "cover",
-                "usageHint": "avatar"
+                "variant": "avatar"
             }
         """.trimIndent()
 
@@ -111,21 +111,21 @@ class ImageWidgetTest {
         val fitRef = DataReferenceParser.parseString(data["fit"])
         assertEquals("cover", (fitRef as LiteralString).value)
 
-        val hintRef = DataReferenceParser.parseString(data["usageHint"])
-        assertEquals("avatar", (hintRef as LiteralString).value)
+        val variantRef = DataReferenceParser.parseString(data["variant"])
+        assertEquals("avatar", (variantRef as LiteralString).value)
     }
 
     @Test
     fun `missing optional properties return null`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://example.com/img.png"}
+                "url": "https://example.com/img.png"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
         assertNull(DataReferenceParser.parseString(data["fit"]))
-        assertNull(DataReferenceParser.parseString(data["usageHint"]))
+        assertNull(DataReferenceParser.parseString(data["variant"]))
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ListWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ListWidgetTest.kt
@@ -26,8 +26,8 @@ import kotlin.test.assertNull
 /**
  * Tests for List widget JSON parsing.
  *
- * A2UI Spec properties:
- * - children (required): Either explicitList or template
+ * A2UI Spec properties (v0.9):
+ * - children (required): Either plain array or template object
  * - direction (optional): vertical, horizontal
  * - alignment (optional): start, center, end
  */
@@ -36,10 +36,10 @@ class ListWidgetTest {
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseChildren extracts explicit list`() {
+    fun `parseChildren extracts plain array`() {
         val jsonStr = """
             {
-                "children": {"explicitList": ["item1", "item2", "item3"]}
+                "children": ["item1", "item2", "item3"]
             }
         """.trimIndent()
 
@@ -52,14 +52,12 @@ class ListWidgetTest {
     }
 
     @Test
-    fun `parseChildren extracts template with dataBinding`() {
+    fun `parseChildren extracts template with path`() {
         val jsonStr = """
             {
                 "children": {
-                    "template": {
-                        "componentId": "item-template",
-                        "dataBinding": "/items"
-                    }
+                    "componentId": "item-template",
+                    "path": "/items"
                 }
             }
         """.trimIndent()
@@ -71,7 +69,7 @@ class ListWidgetTest {
         assertTrue(childrenRef is ChildrenReference.Template)
         val template = childrenRef as ChildrenReference.Template
         assertEquals("item-template", template.componentId)
-        assertEquals("/items", template.dataBinding)
+        assertEquals("/items", template.path)
     }
 
     @Test
@@ -123,10 +121,8 @@ class ListWidgetTest {
         val jsonStr = """
             {
                 "children": {
-                    "template": {
-                        "componentId": "card-template",
-                        "dataBinding": "/products"
-                    }
+                    "componentId": "card-template",
+                    "path": "/products"
                 },
                 "direction": "vertical",
                 "alignment": "center"
@@ -149,7 +145,7 @@ class ListWidgetTest {
     fun `missing optional properties return null`() {
         val jsonStr = """
             {
-                "children": {"explicitList": ["a", "b"]}
+                "children": ["a", "b"]
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ModalWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/ModalWidgetTest.kt
@@ -25,41 +25,41 @@ import kotlin.test.assertNotNull
 /**
  * Tests for Modal widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - entryPointChild (required): Component ID of trigger element
- * - contentChild (required): Component ID of modal content
+ * A2UI Spec properties (v0.9):
+ * - trigger (required): Component ID of trigger element (renamed from entryPointChild)
+ * - content (required): Component ID of modal content (renamed from contentChild)
  */
 class ModalWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseComponentRef extracts entryPointChild`() {
+    fun `parseComponentRef extracts trigger`() {
         val jsonStr = """
             {
-                "entryPointChild": "open-button",
-                "contentChild": "modal-content"
+                "trigger": "open-button",
+                "content": "modal-content"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val entryRef = DataReferenceParser.parseComponentRef(data["entryPointChild"])
+        val triggerRef = DataReferenceParser.parseComponentRef(data["trigger"])
 
-        assertNotNull(entryRef)
-        assertEquals("open-button", entryRef.componentId)
+        assertNotNull(triggerRef)
+        assertEquals("open-button", triggerRef.componentId)
     }
 
     @Test
-    fun `parseComponentRef extracts contentChild`() {
+    fun `parseComponentRef extracts content`() {
         val jsonStr = """
             {
-                "entryPointChild": "trigger",
-                "contentChild": "dialog-content"
+                "trigger": "trigger",
+                "content": "dialog-content"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val contentRef = DataReferenceParser.parseComponentRef(data["contentChild"])
+        val contentRef = DataReferenceParser.parseComponentRef(data["content"])
 
         assertNotNull(contentRef)
         assertEquals("dialog-content", contentRef.componentId)
@@ -69,17 +69,17 @@ class ModalWidgetTest {
     fun `complete Modal with both required properties`() {
         val jsonStr = """
             {
-                "entryPointChild": "settings-button",
-                "contentChild": "settings-panel"
+                "trigger": "settings-button",
+                "content": "settings-panel"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val entryRef = DataReferenceParser.parseComponentRef(data["entryPointChild"])
-        assertEquals("settings-button", entryRef?.componentId)
+        val triggerRef = DataReferenceParser.parseComponentRef(data["trigger"])
+        assertEquals("settings-button", triggerRef?.componentId)
 
-        val contentRef = DataReferenceParser.parseComponentRef(data["contentChild"])
+        val contentRef = DataReferenceParser.parseComponentRef(data["content"])
         assertEquals("settings-panel", contentRef?.componentId)
     }
 
@@ -87,17 +87,17 @@ class ModalWidgetTest {
     fun `Modal with nested component IDs containing hyphens`() {
         val jsonStr = """
             {
-                "entryPointChild": "my-custom-trigger-button",
-                "contentChild": "my-complex-modal-content-area"
+                "trigger": "my-custom-trigger-button",
+                "content": "my-complex-modal-content-area"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val entryRef = DataReferenceParser.parseComponentRef(data["entryPointChild"])
-        assertEquals("my-custom-trigger-button", entryRef?.componentId)
+        val triggerRef = DataReferenceParser.parseComponentRef(data["trigger"])
+        assertEquals("my-custom-trigger-button", triggerRef?.componentId)
 
-        val contentRef = DataReferenceParser.parseComponentRef(data["contentChild"])
+        val contentRef = DataReferenceParser.parseComponentRef(data["content"])
         assertEquals("my-complex-modal-content-area", contentRef?.componentId)
     }
 
@@ -106,18 +106,18 @@ class ModalWidgetTest {
         // Matches the pattern used in WidgetSamples
         val jsonStr = """
             {
-                "entryPointChild": "trigger",
-                "contentChild": "modal-content"
+                "trigger": "trigger",
+                "content": "modal-content"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val entryRef = DataReferenceParser.parseComponentRef(data["entryPointChild"])
-        assertNotNull(entryRef)
-        assertEquals("trigger", entryRef.componentId)
+        val triggerRef = DataReferenceParser.parseComponentRef(data["trigger"])
+        assertNotNull(triggerRef)
+        assertEquals("trigger", triggerRef.componentId)
 
-        val contentRef = DataReferenceParser.parseComponentRef(data["contentChild"])
+        val contentRef = DataReferenceParser.parseComponentRef(data["content"])
         assertNotNull(contentRef)
         assertEquals("modal-content", contentRef.componentId)
     }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/RowColumnWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/RowColumnWidgetTest.kt
@@ -25,11 +25,12 @@ import kotlin.test.assertNotNull
 /**
  * Tests for Row and Column widget property parsing.
  *
- * A2UI Spec supported values:
- * - Row distribution: "start", "center", "end", "spaceBetween", "spaceAround", "spaceEvenly", "stretch"
- * - Row alignment: "start", "center", "end", "stretch"
- * - Column distribution: "start", "center", "end", "spaceBetween", "spaceAround", "spaceEvenly", "stretch"
- * - Column alignment: "start", "center", "end", "stretch"
+ * A2UI Spec v0.9 supported values:
+ * - Row justify: "start", "center", "end", "spaceBetween", "spaceAround", "spaceEvenly", "stretch"
+ * - Row align: "start", "center", "end", "stretch"
+ * - Column justify: "start", "center", "end", "spaceBetween", "spaceAround", "spaceEvenly", "stretch"
+ * - Column align: "start", "center", "end", "stretch"
+ * - children: plain array of component IDs (v0.9 format)
  */
 class RowColumnWidgetTest {
 
@@ -37,113 +38,113 @@ class RowColumnWidgetTest {
 
     // Tests for children parsing
     @Test
-    fun `parseComponentArray extracts explicit list of children`() {
+    fun `parseChildren extracts plain array of children`() {
         val jsonStr = """
             {
-                "children": {"explicitList": ["child1", "child2", "child3"]}
+                "children": ["child1", "child2", "child3"]
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val childrenRef = DataReferenceParser.parseComponentArray(data["children"])
+        val childrenRef = DataReferenceParser.parseChildren(data["children"])
 
         assertNotNull(childrenRef)
-        assertEquals(listOf("child1", "child2", "child3"), childrenRef.componentIds)
+        assertEquals(listOf("child1", "child2", "child3"), (childrenRef as ChildrenReference.ExplicitList).componentIds)
     }
 
-    // Tests for distribution parsing
+    // Tests for justify parsing (renamed from distribution)
     @Test
-    fun `parseString extracts distribution value`() {
-        val distributions = listOf(
+    fun `parseString extracts justify value`() {
+        val justifyValues = listOf(
             "start", "center", "end",
             "spaceBetween", "spaceAround", "spaceEvenly",
             "stretch"
         )
 
-        distributions.forEach { dist ->
-            val jsonStr = """{"distribution": "$dist"}"""
+        justifyValues.forEach { justify ->
+            val jsonStr = """{"justify": "$justify"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
-            val ref = DataReferenceParser.parseString(data["distribution"])
+            val ref = DataReferenceParser.parseString(data["justify"])
 
-            assertNotNull(ref, "Distribution '$dist' should parse")
-            assertEquals(dist, (ref as LiteralString).value)
+            assertNotNull(ref, "justify '$justify' should parse")
+            assertEquals(justify, (ref as LiteralString).value)
         }
     }
 
-    // Tests for alignment parsing
+    // Tests for align parsing (renamed from alignment)
     @Test
-    fun `parseString extracts alignment value`() {
-        val alignments = listOf("start", "center", "end", "stretch")
+    fun `parseString extracts align value`() {
+        val alignValues = listOf("start", "center", "end", "stretch")
 
-        alignments.forEach { align ->
-            val jsonStr = """{"alignment": "$align"}"""
+        alignValues.forEach { align ->
+            val jsonStr = """{"align": "$align"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
-            val ref = DataReferenceParser.parseString(data["alignment"])
+            val ref = DataReferenceParser.parseString(data["align"])
 
-            assertNotNull(ref, "Alignment '$align' should parse")
+            assertNotNull(ref, "align '$align' should parse")
             assertEquals(align, (ref as LiteralString).value)
         }
     }
 
     // Tests for Row with all properties
     @Test
-    fun `Row with distribution and alignment`() {
+    fun `Row with justify and align`() {
         val jsonStr = """
             {
-                "children": {"explicitList": ["left", "center", "right"]},
-                "distribution": "spaceBetween",
-                "alignment": "center"
+                "children": ["left", "center", "right"],
+                "justify": "spaceBetween",
+                "align": "center"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val childrenRef = DataReferenceParser.parseComponentArray(data["children"])
+        val childrenRef = DataReferenceParser.parseChildren(data["children"])
         assertNotNull(childrenRef)
-        assertEquals(3, childrenRef.componentIds.size)
+        assertEquals(3, (childrenRef as ChildrenReference.ExplicitList).componentIds.size)
 
-        val distRef = DataReferenceParser.parseString(data["distribution"])
-        assertEquals("spaceBetween", (distRef as LiteralString).value)
+        val justifyRef = DataReferenceParser.parseString(data["justify"])
+        assertEquals("spaceBetween", (justifyRef as LiteralString).value)
 
-        val alignRef = DataReferenceParser.parseString(data["alignment"])
+        val alignRef = DataReferenceParser.parseString(data["align"])
         assertEquals("center", (alignRef as LiteralString).value)
     }
 
     // Tests for Column with all properties
     @Test
-    fun `Column with distribution and alignment`() {
+    fun `Column with justify and align`() {
         val jsonStr = """
             {
-                "children": {"explicitList": ["header", "content", "footer"]},
-                "distribution": "spaceEvenly",
-                "alignment": "center"
+                "children": ["header", "content", "footer"],
+                "justify": "spaceEvenly",
+                "align": "center"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val childrenRef = DataReferenceParser.parseComponentArray(data["children"])
+        val childrenRef = DataReferenceParser.parseChildren(data["children"])
         assertNotNull(childrenRef)
-        assertEquals(3, childrenRef.componentIds.size)
+        assertEquals(3, (childrenRef as ChildrenReference.ExplicitList).componentIds.size)
 
-        val distRef = DataReferenceParser.parseString(data["distribution"])
-        assertEquals("spaceEvenly", (distRef as LiteralString).value)
+        val justifyRef = DataReferenceParser.parseString(data["justify"])
+        assertEquals("spaceEvenly", (justifyRef as LiteralString).value)
 
-        val alignRef = DataReferenceParser.parseString(data["alignment"])
+        val alignRef = DataReferenceParser.parseString(data["align"])
         assertEquals("center", (alignRef as LiteralString).value)
     }
 
     // Test path-based values for dynamic binding
     @Test
-    fun `distribution from path binding`() {
+    fun `justify from path binding`() {
         val jsonStr = """
             {
-                "distribution": {"path": "/ui/rowDistribution"}
+                "justify": {"path": "/ui/rowDistribution"}
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val ref = DataReferenceParser.parseString(data["distribution"])
+        val ref = DataReferenceParser.parseString(data["justify"])
 
         assertNotNull(ref)
         assertEquals("/ui/rowDistribution", (ref as PathString).path)

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/SliderWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/SliderWidgetTest.kt
@@ -26,10 +26,10 @@ import kotlin.test.assertNull
 /**
  * Tests for Slider widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
+ * A2UI Spec properties (v0.9):
  * - value (required): Path binding for numeric value
- * - minValue (optional): Minimum value
- * - maxValue (optional): Maximum value
+ * - min (optional): Minimum value (renamed from minValue)
+ * - max (optional): Maximum value (renamed from maxValue)
  */
 class SliderWidgetTest {
 
@@ -51,32 +51,32 @@ class SliderWidgetTest {
     }
 
     @Test
-    fun `parseNumber extracts minValue`() {
+    fun `parseNumber extracts min`() {
         val jsonStr = """
             {
                 "value": {"path": "/volume"},
-                "minValue": 0
+                "min": 0
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val minRef = DataReferenceParser.parseNumber(data["minValue"])
+        val minRef = DataReferenceParser.parseNumber(data["min"])
 
         assertNotNull(minRef)
         assertEquals(0.0, (minRef as LiteralNumber).value)
     }
 
     @Test
-    fun `parseNumber extracts maxValue`() {
+    fun `parseNumber extracts max`() {
         val jsonStr = """
             {
                 "value": {"path": "/volume"},
-                "maxValue": 100
+                "max": 100
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val maxRef = DataReferenceParser.parseNumber(data["maxValue"])
+        val maxRef = DataReferenceParser.parseNumber(data["max"])
 
         assertNotNull(maxRef)
         assertEquals(100.0, (maxRef as LiteralNumber).value)
@@ -86,17 +86,17 @@ class SliderWidgetTest {
     fun `parseNumber handles decimal values`() {
         val jsonStr = """
             {
-                "minValue": 0.5,
-                "maxValue": 1.5
+                "min": 0.5,
+                "max": 1.5
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val minRef = DataReferenceParser.parseNumber(data["minValue"])
+        val minRef = DataReferenceParser.parseNumber(data["min"])
         assertEquals(0.5, (minRef as LiteralNumber).value)
 
-        val maxRef = DataReferenceParser.parseNumber(data["maxValue"])
+        val maxRef = DataReferenceParser.parseNumber(data["max"])
         assertEquals(1.5, (maxRef as LiteralNumber).value)
     }
 
@@ -105,8 +105,8 @@ class SliderWidgetTest {
         val jsonStr = """
             {
                 "value": {"path": "/brightness"},
-                "minValue": 0,
-                "maxValue": 100
+                "min": 0,
+                "max": 100
             }
         """.trimIndent()
 
@@ -115,10 +115,10 @@ class SliderWidgetTest {
         val valueRef = DataReferenceParser.parseString(data["value"])
         assertEquals("/brightness", (valueRef as PathString).path)
 
-        val minRef = DataReferenceParser.parseNumber(data["minValue"])
+        val minRef = DataReferenceParser.parseNumber(data["min"])
         assertEquals(0.0, (minRef as LiteralNumber).value)
 
-        val maxRef = DataReferenceParser.parseNumber(data["maxValue"])
+        val maxRef = DataReferenceParser.parseNumber(data["max"])
         assertEquals(100.0, (maxRef as LiteralNumber).value)
     }
 
@@ -132,23 +132,23 @@ class SliderWidgetTest {
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        assertNull(DataReferenceParser.parseNumber(data["minValue"]))
-        assertNull(DataReferenceParser.parseNumber(data["maxValue"]))
+        assertNull(DataReferenceParser.parseNumber(data["min"]))
+        assertNull(DataReferenceParser.parseNumber(data["max"]))
     }
 
     @Test
-    fun `negative minValue is valid`() {
+    fun `negative min is valid`() {
         val jsonStr = """
             {
                 "value": {"path": "/temperature"},
-                "minValue": -50,
-                "maxValue": 50
+                "min": -50,
+                "max": 50
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val minRef = DataReferenceParser.parseNumber(data["minValue"])
+        val minRef = DataReferenceParser.parseNumber(data["min"])
         assertEquals(-50.0, (minRef as LiteralNumber).value)
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TabsWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TabsWidgetTest.kt
@@ -29,29 +29,29 @@ import kotlin.test.assertTrue
 /**
  * Tests for Tabs widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - tabItems (required): Array of tab definitions with title and child
+ * A2UI Spec properties (v0.9):
+ * - tabs (required): Array of tab definitions with title and child (renamed from tabItems)
  */
 class TabsWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts tab title literalString`() {
+    fun `parseString extracts tab title literal`() {
         val jsonStr = """
             {
-                "tabItems": [
-                    {"title": {"literalString": "Home"}, "child": "home-content"}
+                "tabs": [
+                    {"title": "Home", "child": "home-content"}
                 ]
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
-        assertNotNull(tabItems)
-        assertEquals(1, tabItems.size)
+        val tabs = data["tabs"]?.jsonArray
+        assertNotNull(tabs)
+        assertEquals(1, tabs.size)
 
-        val firstTab = tabItems[0].jsonObject
+        val firstTab = tabs[0].jsonObject
         val titleRef = DataReferenceParser.parseString(firstTab["title"])
 
         assertNotNull(titleRef)
@@ -62,17 +62,17 @@ class TabsWidgetTest {
     fun `parseString extracts tab title path binding`() {
         val jsonStr = """
             {
-                "tabItems": [
+                "tabs": [
                     {"title": {"path": "/tabs/0/label"}, "child": "tab-content"}
                 ]
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
-        assertNotNull(tabItems)
+        val tabs = data["tabs"]?.jsonArray
+        assertNotNull(tabs)
 
-        val firstTab = tabItems[0].jsonObject
+        val firstTab = tabs[0].jsonObject
         val titleRef = DataReferenceParser.parseString(firstTab["title"])
 
         assertNotNull(titleRef)
@@ -83,17 +83,17 @@ class TabsWidgetTest {
     fun `parseComponentRef extracts tab child`() {
         val jsonStr = """
             {
-                "tabItems": [
+                "tabs": [
                     {"title": "Settings", "child": "settings-panel"}
                 ]
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
-        assertNotNull(tabItems)
+        val tabs = data["tabs"]?.jsonArray
+        assertNotNull(tabs)
 
-        val firstTab = tabItems[0].jsonObject
+        val firstTab = tabs[0].jsonObject
         val childRef = DataReferenceParser.parseComponentRef(firstTab["child"])
 
         assertNotNull(childRef)
@@ -104,20 +104,20 @@ class TabsWidgetTest {
     fun `multiple tabs with different titles`() {
         val jsonStr = """
             {
-                "tabItems": [
-                    {"title": {"literalString": "Tab 1"}, "child": "content-1"},
-                    {"title": {"literalString": "Tab 2"}, "child": "content-2"},
-                    {"title": {"literalString": "Tab 3"}, "child": "content-3"}
+                "tabs": [
+                    {"title": "Tab 1", "child": "content-1"},
+                    {"title": "Tab 2", "child": "content-2"},
+                    {"title": "Tab 3", "child": "content-3"}
                 ]
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
-        assertNotNull(tabItems)
-        assertEquals(3, tabItems.size)
+        val tabs = data["tabs"]?.jsonArray
+        assertNotNull(tabs)
+        assertEquals(3, tabs.size)
 
-        val titles = tabItems.map { tab ->
+        val titles = tabs.map { tab ->
             val titleRef = DataReferenceParser.parseString(tab.jsonObject["title"])
             (titleRef as? LiteralString)?.value
         }
@@ -129,7 +129,7 @@ class TabsWidgetTest {
     fun `tab with hyphenated child IDs`() {
         val jsonStr = """
             {
-                "tabItems": [
+                "tabs": [
                     {"title": "Overview", "child": "product-overview-panel"},
                     {"title": "Details", "child": "product-details-section"}
                 ]
@@ -137,38 +137,38 @@ class TabsWidgetTest {
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
-        assertNotNull(tabItems)
+        val tabs = data["tabs"]?.jsonArray
+        assertNotNull(tabs)
 
-        val firstTab = tabItems[0].jsonObject
+        val firstTab = tabs[0].jsonObject
         val childRef = DataReferenceParser.parseComponentRef(firstTab["child"])
         assertEquals("product-overview-panel", childRef?.componentId)
 
-        val secondTab = tabItems[1].jsonObject
+        val secondTab = tabs[1].jsonObject
         val childRef2 = DataReferenceParser.parseComponentRef(secondTab["child"])
         assertEquals("product-details-section", childRef2?.componentId)
     }
 
     @Test
-    fun `empty tabItems array`() {
+    fun `empty tabs array`() {
         val jsonStr = """
             {
-                "tabItems": []
+                "tabs": []
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val tabItems = data["tabItems"]?.jsonArray
+        val tabs = data["tabs"]?.jsonArray
 
-        assertNotNull(tabItems)
-        assertTrue(tabItems.isEmpty())
+        assertNotNull(tabs)
+        assertTrue(tabs.isEmpty())
     }
 
     @Test
-    fun `missing tabItems returns null`() {
+    fun `missing tabs returns null`() {
         val jsonStr = """{}"""
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        assertNull(data["tabItems"])
+        assertNull(data["tabs"])
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TextFieldWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TextFieldWidgetTest.kt
@@ -26,10 +26,10 @@ import kotlin.test.assertNull
 /**
  * Tests for TextField widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - text (required): Path binding for the text value
- * - label (optional): Label text as literalString or path
- * - textFieldType (optional): date, longText, number, shortText, obscured
+ * A2UI Spec properties (v0.9):
+ * - value (required): Path binding for the text value (renamed from text)
+ * - label (optional): Label text as plain string or path binding
+ * - variant (optional): date, longText, number, shortText, obscured (renamed from textFieldType)
  * - validationRegexp (optional): Regex pattern for validation
  */
 class TextFieldWidgetTest {
@@ -37,26 +37,26 @@ class TextFieldWidgetTest {
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts text path binding`() {
+    fun `parseString extracts value path binding`() {
         val jsonStr = """
             {
-                "text": {"path": "/form/username"}
+                "value": {"path": "/form/username"}
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val textRef = DataReferenceParser.parseString(data["text"])
+        val valueRef = DataReferenceParser.parseString(data["value"])
 
-        assertNotNull(textRef)
-        assertEquals("/form/username", (textRef as PathString).path)
+        assertNotNull(valueRef)
+        assertEquals("/form/username", (valueRef as PathString).path)
     }
 
     @Test
-    fun `parseString extracts label literalString`() {
+    fun `parseString extracts label literal`() {
         val jsonStr = """
             {
-                "text": {"path": "/name"},
-                "label": {"literalString": "Enter your name"}
+                "value": {"path": "/name"},
+                "label": "Enter your name"
             }
         """.trimIndent()
 
@@ -68,15 +68,15 @@ class TextFieldWidgetTest {
     }
 
     @Test
-    fun `all textFieldType values are valid`() {
+    fun `all variant values are valid`() {
         val types = listOf("date", "longText", "number", "shortText", "obscured")
 
         types.forEach { type ->
-            val jsonStr = """{"textFieldType": "$type"}"""
+            val jsonStr = """{"variant": "$type"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
-            val ref = DataReferenceParser.parseString(data["textFieldType"])
+            val ref = DataReferenceParser.parseString(data["variant"])
 
-            assertNotNull(ref, "textFieldType '$type' should parse")
+            assertNotNull(ref, "variant '$type' should parse")
             assertEquals(type, (ref as LiteralString).value)
         }
     }
@@ -85,7 +85,7 @@ class TextFieldWidgetTest {
     fun `parseString extracts validationRegexp`() {
         val jsonStr = """
             {
-                "text": {"path": "/email"},
+                "value": {"path": "/email"},
                 "validationRegexp": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
             }
         """.trimIndent()
@@ -100,14 +100,14 @@ class TextFieldWidgetTest {
     fun `missing optional properties return null`() {
         val jsonStr = """
             {
-                "text": {"path": "/value"}
+                "value": {"path": "/value"}
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
         assertNull(DataReferenceParser.parseString(data["label"]))
-        assertNull(DataReferenceParser.parseString(data["textFieldType"]))
+        assertNull(DataReferenceParser.parseString(data["variant"]))
         assertNull(DataReferenceParser.parseString(data["validationRegexp"]))
     }
 
@@ -115,21 +115,21 @@ class TextFieldWidgetTest {
     fun `complete TextField with all properties`() {
         val jsonStr = """
             {
-                "text": {"path": "/form/password"},
-                "label": {"literalString": "Password"},
-                "textFieldType": "obscured"
+                "value": {"path": "/form/password"},
+                "label": "Password",
+                "variant": "obscured"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
 
-        val textRef = DataReferenceParser.parseString(data["text"])
-        assertEquals("/form/password", (textRef as PathString).path)
+        val valueRef = DataReferenceParser.parseString(data["value"])
+        assertEquals("/form/password", (valueRef as PathString).path)
 
         val labelRef = DataReferenceParser.parseString(data["label"])
         assertEquals("Password", (labelRef as LiteralString).value)
 
-        val typeRef = DataReferenceParser.parseString(data["textFieldType"])
-        assertEquals("obscured", (typeRef as LiteralString).value)
+        val variantRef = DataReferenceParser.parseString(data["variant"])
+        assertEquals("obscured", (variantRef as LiteralString).value)
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TextWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/TextWidgetTest.kt
@@ -26,19 +26,19 @@ import kotlin.test.assertNull
 /**
  * Tests for Text widget JSON parsing.
  *
- * A2UI Spec properties:
- * - text (required): String content as literalString or path
- * - usageHint (optional): h1, h2, h3, h4, h5, body, caption
+ * A2UI Spec properties (v0.9):
+ * - text (required): String content as plain string or path binding
+ * - variant (optional): h1, h2, h3, h4, h5, body, caption
  */
 class TextWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts literalString text`() {
+    fun `parseString extracts literal text`() {
         val jsonStr = """
             {
-                "text": {"literalString": "Hello World"}
+                "text": "Hello World"
             }
         """.trimIndent()
 
@@ -65,54 +65,54 @@ class TextWidgetTest {
     }
 
     @Test
-    fun `parseString extracts usageHint h1`() {
+    fun `parseString extracts variant h1`() {
         val jsonStr = """
             {
-                "text": {"literalString": "Title"},
-                "usageHint": "h1"
+                "text": "Title",
+                "variant": "h1"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val usageRef = DataReferenceParser.parseString(data["usageHint"])
+        val variantRef = DataReferenceParser.parseString(data["variant"])
 
-        assertNotNull(usageRef)
-        assertEquals("h1", (usageRef as LiteralString).value)
+        assertNotNull(variantRef)
+        assertEquals("h1", (variantRef as LiteralString).value)
     }
 
     @Test
-    fun `all usageHint values are valid`() {
-        val usageHints = listOf("h1", "h2", "h3", "h4", "h5", "body", "caption")
+    fun `all variant values are valid`() {
+        val variants = listOf("h1", "h2", "h3", "h4", "h5", "body", "caption")
 
-        usageHints.forEach { hint ->
-            val jsonStr = """{"usageHint": "$hint"}"""
+        variants.forEach { variant ->
+            val jsonStr = """{"variant": "$variant"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
-            val ref = DataReferenceParser.parseString(data["usageHint"])
+            val ref = DataReferenceParser.parseString(data["variant"])
 
-            assertNotNull(ref, "usageHint '$hint' should parse")
-            assertEquals(hint, (ref as LiteralString).value)
+            assertNotNull(ref, "variant '$variant' should parse")
+            assertEquals(variant, (ref as LiteralString).value)
         }
     }
 
     @Test
-    fun `missing usageHint returns null`() {
+    fun `missing variant returns null`() {
         val jsonStr = """
             {
-                "text": {"literalString": "No hint"}
+                "text": "No hint"
             }
         """.trimIndent()
 
         val data = json.decodeFromString<JsonObject>(jsonStr)
-        val usageRef = DataReferenceParser.parseString(data["usageHint"])
+        val variantRef = DataReferenceParser.parseString(data["variant"])
 
-        assertNull(usageRef)
+        assertNull(variantRef)
     }
 
     @Test
     fun `text with markdown content parses correctly`() {
         val jsonStr = """
             {
-                "text": {"literalString": "This is **bold** and _italic_ text"}
+                "text": "This is **bold** and _italic_ text"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/UiDefinitionTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/UiDefinitionTest.kt
@@ -25,6 +25,9 @@ import kotlin.test.assertTrue
 
 /**
  * Tests for UiDefinition - the complete state of a UI surface.
+ *
+ * In v0.9, root is identified by convention (component with id "root")
+ * rather than an explicit root property.
  */
 class UiDefinitionTest {
 
@@ -34,12 +37,11 @@ class UiDefinitionTest {
 
         assertEquals("test-surface", def.surfaceId)
         assertTrue(def.components.isEmpty())
-        assertNull(def.root)
         assertNull(def.catalogId)
     }
 
     @Test
-    fun `rootComponent returns null when root not set`() {
+    fun `rootComponent returns null when no root component exists`() {
         val def = UiDefinition(surfaceId = "test")
 
         assertNull(def.rootComponent)
@@ -47,21 +49,21 @@ class UiDefinitionTest {
 
     @Test
     fun `rootComponent returns null when root ID not in components`() {
+        val comp = Component.create("not-root", "Text", JsonObject(emptyMap()))
         val def = UiDefinition(
             surfaceId = "test",
-            root = "missing-root"
+            components = mapOf("not-root" to comp)
         )
 
         assertNull(def.rootComponent)
     }
 
     @Test
-    fun `rootComponent returns component when found`() {
+    fun `rootComponent returns component with id root`() {
         val component = Component.create("root", "Column", JsonObject(emptyMap()))
         val def = UiDefinition(
             surfaceId = "test",
-            components = mapOf("root" to component),
-            root = "root"
+            components = mapOf("root" to component)
         )
 
         assertNotNull(def.rootComponent)
@@ -114,50 +116,17 @@ class UiDefinitionTest {
     }
 
     @Test
-    fun `withRoot sets root ID`() {
-        val initial = UiDefinition(surfaceId = "test")
-
-        val updated = initial.withRoot("my-root")
-
-        assertEquals("my-root", updated.root)
-    }
-
-    @Test
-    fun `withRoot sets catalogId when provided`() {
-        val initial = UiDefinition(surfaceId = "test")
-
-        val updated = initial.withRoot("root", "custom-catalog")
-
-        assertEquals("root", updated.root)
-        assertEquals("custom-catalog", updated.catalogId)
-    }
-
-    @Test
-    fun `withRoot preserves existing catalogId when not provided`() {
-        val initial = UiDefinition(
-            surfaceId = "test",
-            catalogId = "existing-catalog"
-        )
-
-        val updated = initial.withRoot("root")
-
-        assertEquals("root", updated.root)
-        assertEquals("existing-catalog", updated.catalogId)
-    }
-
-    @Test
     fun `UiDefinition preserves all properties`() {
-        val comp = Component.create("text", "Text", JsonObject(emptyMap()))
+        val comp = Component.create("root", "Text", JsonObject(emptyMap()))
         val def = UiDefinition(
             surfaceId = "main-surface",
-            components = mapOf("text" to comp),
-            root = "text",
+            components = mapOf("root" to comp),
             catalogId = "my-catalog"
         )
 
         assertEquals("main-surface", def.surfaceId)
         assertEquals(1, def.components.size)
-        assertEquals("text", def.root)
+        assertNotNull(def.rootComponent)
         assertEquals("my-catalog", def.catalogId)
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/UiEventTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/UiEventTest.kt
@@ -27,19 +27,19 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Tests for UiEvent types - UserActionEvent and DataChangeEvent.
+ * Tests for UiEvent types - ActionEvent and DataChangeEvent.
  *
- * These tests verify A2UI ClientEvent format compliance.
+ * These tests verify A2UI v0.9 ClientEvent format compliance.
  */
 class UiEventTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    // ========== UserActionEvent tests ==========
+    // ========== ActionEvent tests ==========
 
     @Test
-    fun `UserActionEvent has correct properties`() {
-        val event = UserActionEvent(
+    fun `ActionEvent has correct properties`() {
+        val event = ActionEvent(
             name = "submit",
             surfaceId = "main",
             sourceComponentId = "submit-button",
@@ -54,13 +54,13 @@ class UiEventTest {
     }
 
     @Test
-    fun `UserActionEvent with context`() {
+    fun `ActionEvent with context`() {
         val context = JsonObject(mapOf(
             "itemId" to JsonPrimitive("item-123"),
             "quantity" to JsonPrimitive(2)
         ))
 
-        val event = UserActionEvent(
+        val event = ActionEvent(
             name = "add-to-cart",
             surfaceId = "product-page",
             sourceComponentId = "add-button:item-123",
@@ -73,8 +73,8 @@ class UiEventTest {
     }
 
     @Test
-    fun `UserActionEvent serializes to JSON`() {
-        val event = UserActionEvent(
+    fun `ActionEvent serializes to JSON`() {
+        val event = ActionEvent(
             name = "click",
             surfaceId = "default",
             sourceComponentId = "btn1",
@@ -91,7 +91,7 @@ class UiEventTest {
     }
 
     @Test
-    fun `UserActionEvent deserializes from JSON`() {
+    fun `ActionEvent deserializes from JSON`() {
         val jsonStr = """
             {
                 "name": "action_name",
@@ -102,7 +102,7 @@ class UiEventTest {
             }
         """.trimIndent()
 
-        val event = json.decodeFromString<UserActionEvent>(jsonStr)
+        val event = json.decodeFromString<ActionEvent>(jsonStr)
 
         assertEquals("action_name", event.name)
         assertEquals("default", event.surfaceId)
@@ -112,8 +112,8 @@ class UiEventTest {
     }
 
     @Test
-    fun `UserActionEvent with template item suffix`() {
-        val event = UserActionEvent(
+    fun `ActionEvent with template item suffix`() {
+        val event = ActionEvent(
             name = "select",
             surfaceId = "list",
             sourceComponentId = "item-template:3",

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/VideoWidgetTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/model/VideoWidgetTest.kt
@@ -26,18 +26,18 @@ import kotlin.test.assertNull
 /**
  * Tests for Video widget JSON parsing.
  *
- * A2UI Spec properties (v0.8):
- * - url (required): URL of the video source
+ * A2UI Spec properties (v0.9):
+ * - url (required): URL of the video source as plain string or path binding
  */
 class VideoWidgetTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `parseString extracts url literalString`() {
+    fun `parseString extracts url literal`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://example.com/video.mp4"}
+                "url": "https://example.com/video.mp4"
             }
         """.trimIndent()
 
@@ -67,7 +67,7 @@ class VideoWidgetTest {
     fun `video url with query parameters`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://cdn.example.com/video.mp4?token=abc123&quality=hd"}
+                "url": "https://cdn.example.com/video.mp4?token=abc123&quality=hd"
             }
         """.trimIndent()
 
@@ -83,7 +83,7 @@ class VideoWidgetTest {
         val extensions = listOf("mp4", "webm", "mov", "avi", "m3u8")
 
         extensions.forEach { ext ->
-            val jsonStr = """{"url": {"literalString": "https://example.com/video.$ext"}}"""
+            val jsonStr = """{"url": "https://example.com/video.$ext"}"""
             val data = json.decodeFromString<JsonObject>(jsonStr)
             val urlRef = DataReferenceParser.parseString(data["url"])
 
@@ -104,7 +104,7 @@ class VideoWidgetTest {
     fun `youtube embed url`() {
         val jsonStr = """
             {
-                "url": {"literalString": "https://www.youtube.com/embed/dQw4w9WgXcQ"}
+                "url": "https://www.youtube.com/embed/dQw4w9WgXcQ"
             }
         """.trimIndent()
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/util/PropertyValidationTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/util/PropertyValidationTest.kt
@@ -32,9 +32,9 @@ class PropertyValidationTest {
     fun `warnUnexpectedProperties with all expected properties`() {
         val data = JsonObject(mapOf(
             "text" to JsonPrimitive("Hello"),
-            "usageHint" to JsonPrimitive("h1")
+            "variant" to JsonPrimitive("h1")
         ))
-        val expected = setOf("text", "usageHint")
+        val expected = setOf("text", "variant")
 
         // Should not warn - all properties are expected
         PropertyValidation.warnUnexpectedProperties("Text", data, expected)
@@ -46,7 +46,7 @@ class PropertyValidationTest {
             "text" to JsonPrimitive("Hello"),
             "unknownProp" to JsonPrimitive("value")
         ))
-        val expected = setOf("text", "usageHint")
+        val expected = setOf("text", "variant")
 
         // Should warn about "unknownProp"
         PropertyValidation.warnUnexpectedProperties("Text", data, expected)
@@ -68,7 +68,7 @@ class PropertyValidationTest {
     @Test
     fun `warnUnexpectedProperties with empty data`() {
         val data = JsonObject(emptyMap())
-        val expected = setOf("text", "usageHint")
+        val expected = setOf("text", "variant")
 
         // Should not warn - no unexpected properties
         PropertyValidation.warnUnexpectedProperties("Text", data, expected)
@@ -100,12 +100,12 @@ class PropertyValidationTest {
     @Test
     fun `warnUnexpectedProperties with Image widget`() {
         val data = JsonObject(mapOf(
-            "url" to JsonObject(mapOf("literalString" to JsonPrimitive("https://example.com/img.jpg"))),
+            "url" to JsonPrimitive("https://example.com/img.jpg"),
             "fit" to JsonPrimitive("cover"),
-            "usageHint" to JsonPrimitive("avatar"),
+            "variant" to JsonPrimitive("avatar"),
             "altText" to JsonPrimitive("not in spec")  // Should warn
         ))
-        val expected = setOf("url", "fit", "usageHint")
+        val expected = setOf("url", "fit", "variant")
 
         PropertyValidation.warnUnexpectedProperties("Image", data, expected)
     }
@@ -114,10 +114,10 @@ class PropertyValidationTest {
     fun `warnUnexpectedProperties with Row widget`() {
         val data = JsonObject(mapOf(
             "children" to JsonObject(emptyMap()),
-            "alignment" to JsonPrimitive("center"),
+            "align" to JsonPrimitive("center"),
             "gap" to JsonPrimitive(8)  // Not in A2UI spec - should warn
         ))
-        val expected = setOf("children", "alignment")
+        val expected = setOf("children", "align")
 
         PropertyValidation.warnUnexpectedProperties("Row", data, expected)
     }


### PR DESCRIPTION
Major protocol changes:
- Operations renamed: beginRendering→createSurface, surfaceUpdate→updateComponents, dataModelUpdate→updateDataModel
- Component format: nested discriminator→flat format with "component" string type
- Data references: explicit wrappers (literalString)→implicit typing (plain values)
- Children format: wrapped objects→plain arrays and template {componentId, path}
- Widget renames: MultipleChoice→ChoicePicker, property renames across all widgets (distribution→justify, alignment→align, usageHint→variant, etc.)
- Event rename: UserActionEvent→ActionEvent
- Button action format: {name, context:[{key,value}]}→{event:{name, context:{...}}}
- Root component: explicit root property→convention (id="root")

New v0.9 features:
- FunctionCall evaluation infrastructure (validation, formatting, logic functions)
- FunctionCallReference support in DataReference parsing
- DataModel.delete() for upsert/delete semantics
- Theme and sendDataModel support in UiDefinition/CreateSurface
- ValidationError event type
- ChoicePicker widget (replacing MultipleChoice) with variant/displayStyle

Updated all 18 widgets, 26 test files, and example catalog app.