### PR TITLE
Fix toBigDecimal() usage in commonMain breaking non-JVM targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-14
+
+A2UI protocol upgrade from v0.8 to v0.9. This is a **breaking release** that changes the wire format, operation names, component structure, and data binding system.
+
+### Added
+- Function evaluation engine (`FunctionEvaluator`) with 13 standard functions:
+  - Validation: `required`, `regex`, `length`, `numeric`, `email`
+  - Logic: `and`, `or`, `not`
+  - Formatting: `formatString`, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`
+- `FunctionCallReference<T>` data reference type for computed values via `{"call": "fn", "args": {...}}`
+- `ValidationError` event type for client-to-server validation reporting (`VALIDATION_FAILED`)
+- `DataModel.delete(path)` for removing keys (v0.9: omitting `value` in `updateDataModel` deletes the key)
+- `sendDataModel` flag on `createSurface` — when true, client includes full data model in A2A metadata
+- `DataReferenceParser.parseStringList()` for v0.9 plain string arrays
+- `A2UIExtension.PROTOCOL_VERSION` constant (`"v0.9"`)
+- `FunctionEvaluatorTest` covering `formatNumber`, `formatCurrency`, `required`, and `email` functions
+- Alpha/beta pre-release publishing channels:
+  - `publish.sh --channel alpha` / `--channel beta`
+  - Auto-computed version from commit count (e.g., `0.9.0-alpha.3`)
+  - CI workflow updated with channel selection dropdown
+  - Gradle version override via `-PpublishVersion`
+
+### Changed
+- **Operations renamed:**
+  - `beginRendering` → `createSurface` (now takes `catalogId` and optional `theme` instead of `root` and `styles`)
+  - `surfaceUpdate` → `updateComponents`
+  - `dataModelUpdate` → `updateDataModel` (simplified: single `path` + `value` instead of `path` + `contents: List<DataEntry>`)
+- **Component format flattened** (v0.8 nested → v0.9 flat discriminator):
+  - v0.8: `{"id": "x", "component": {"Text": {"text": {"literalString": "Hi"}}}}`
+  - v0.9: `{"id": "x", "component": "Text", "text": "Hi", "variant": "h1"}`
+- **Data references simplified** (implicit typing):
+  - Plain JSON primitives are now literals (`"hello"`, `42`, `true`)
+  - `{"path": "/x"}` for data bindings (unchanged)
+  - `{"call": "fn", "args": {...}}` for function calls (new)
+  - Removed: `{"literalString": "..."}`, `{"literalNumber": 42}`, `{"literalBoolean": true}`
+- **Root component by convention:** root is now the component with `id: "root"` rather than an explicit `root` property on `createSurface`
+- **Event format updated:**
+  - `UserActionEvent` → `ActionEvent`
+  - Action context changed from array of `{key, value}` pairs to flat JSON object
+  - Button actions now use `{"event": {"name": "...", "context": {...}}}` envelope
+- **Widget changes:**
+  - `MultipleChoice` → `ChoicePicker` (supports both single and multiple selection)
+  - Button `primary` boolean and `usageHint` replaced by `variant` string (`"filled"`, `"outlined"`, `"text"`, `"elevated"`, `"tonal"`)
+  - All widgets updated to parse v0.9 flat property format
+- **Component model:**
+  - `Component.componentProperties: Map<String, JsonObject>` → `Component.componentType: String` + `Component.properties: JsonObject`
+  - `widgetType` and `widgetData` are now non-nullable
+- Extension URIs: `A2UIExtension.URI_V08` → `A2UIExtension.URI_V09`
+- Standard catalog URI updated to `v0_9/json/standard_catalog.json`
+- All existing tests updated for v0.9 format
+
+### Removed
+- `DataEntry` class and its nested value types (replaced by direct JSON values in `updateDataModel`)
+- `ComponentArrayReference` and `TemplateReference` types (replaced by `ChildrenReference` sealed class)
+- `UiDefinition.withRoot()` (root is now by convention)
+- `A2UIExtension.URI_V08` constant (replaced by `URI_V09`)
+- Debug print statements from `SurfaceStateManager`
+
+### Fixed
+- `FunctionEvaluator.evaluateFormatNumber()` used JVM-only `Double.toBigDecimal().toPlainString()` in `commonMain`, breaking JS and iOS compilation. Replaced with multiplatform `doubleToPlainString()` helper.
+
 ## [0.8.2] - 2026-02-10
 
 ### Added
@@ -49,7 +110,8 @@ Initial implementation of the A2UI v0.8 rendering engine.
 - Event system: UserActionEvent, DataChangeEvent
 - Kotlin Multiplatform support: Android, iOS, JVM/Desktop
 
-[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/Contextable/a2ui-4k/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/Contextable/a2ui-4k/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Contextable/a2ui-4k/releases/tag/v0.8.0

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/function/FunctionEvaluatorTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/function/FunctionEvaluatorTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 Contextable LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.contextable.a2ui4k.function
+
+import com.contextable.a2ui4k.model.DataContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [FunctionEvaluator], focusing on formatting functions
+ * that must compile and run correctly on all Kotlin targets (JVM, JS, iOS).
+ */
+class FunctionEvaluatorTest {
+
+    private val emptyContext = object : DataContext {
+        override fun getString(path: String): String? = null
+        override fun getNumber(path: String): Double? = null
+        override fun getBoolean(path: String): Boolean? = null
+        override fun getStringList(path: String): List<String>? = null
+        override fun getArraySize(path: String): Int? = null
+        override fun getObjectKeys(path: String): List<String>? = null
+        override fun update(path: String, value: Any?) {}
+        override fun withBasePath(basePath: String): DataContext = this
+    }
+
+    private fun formatNumberArgs(
+        value: Double,
+        minimumFractionDigits: Int? = null,
+        maximumFractionDigits: Int? = null,
+        useGrouping: Boolean? = null
+    ): JsonObject {
+        val map = mutableMapOf<String, JsonPrimitive>("value" to JsonPrimitive(value))
+        minimumFractionDigits?.let { map["minimumFractionDigits"] = JsonPrimitive(it) }
+        maximumFractionDigits?.let { map["maximumFractionDigits"] = JsonPrimitive(it) }
+        useGrouping?.let { map["useGrouping"] = JsonPrimitive(it) }
+        return JsonObject(map)
+    }
+
+    // --- formatNumber tests ---
+
+    @Test
+    fun formatNumber_integer() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 42.0, maximumFractionDigits = 0),
+            emptyContext
+        )
+        assertEquals("42", result)
+    }
+
+    @Test
+    fun formatNumber_withDecimals() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 1234.56, minimumFractionDigits = 2, maximumFractionDigits = 2),
+            emptyContext
+        )
+        assertEquals("1,234.56", result)
+    }
+
+    @Test
+    fun formatNumber_largeNumber() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 1000000.0, maximumFractionDigits = 0),
+            emptyContext
+        )
+        assertEquals("1,000,000", result)
+    }
+
+    @Test
+    fun formatNumber_noGrouping() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 1234.5, useGrouping = false, maximumFractionDigits = 1),
+            emptyContext
+        )
+        assertEquals("1234.5", result)
+    }
+
+    @Test
+    fun formatNumber_minimumFractionDigitsPads() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 5.0, minimumFractionDigits = 2, maximumFractionDigits = 2),
+            emptyContext
+        )
+        assertEquals("5.00", result)
+    }
+
+    @Test
+    fun formatNumber_smallDecimal() {
+        // Regression test: small decimals must not produce scientific notation
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = 0.001, minimumFractionDigits = 3, maximumFractionDigits = 3),
+            emptyContext
+        )
+        assertEquals("0.001", result)
+    }
+
+    @Test
+    fun formatNumber_negativeNumber() {
+        val result = FunctionEvaluator.evaluateString(
+            "formatNumber",
+            formatNumberArgs(value = -1234.5, maximumFractionDigits = 1),
+            emptyContext
+        )
+        assertEquals("-1,234.5", result)
+    }
+
+    // --- formatCurrency tests ---
+
+    @Test
+    fun formatCurrency_usd() {
+        val args = JsonObject(
+            mapOf(
+                "value" to JsonPrimitive(1234.56),
+                "currency" to JsonPrimitive("USD")
+            )
+        )
+        val result = FunctionEvaluator.evaluateString("formatCurrency", args, emptyContext)
+        assertEquals("$1,234.56", result)
+    }
+
+    // --- required validation tests ---
+
+    @Test
+    fun required_emptyString_isFalse() {
+        val args = JsonObject(mapOf("value" to JsonPrimitive("")))
+        val result = FunctionEvaluator.evaluateBoolean("required", args, emptyContext)
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun required_nonEmpty_isTrue() {
+        val args = JsonObject(mapOf("value" to JsonPrimitive("hello")))
+        val result = FunctionEvaluator.evaluateBoolean("required", args, emptyContext)
+        assertEquals(true, result)
+    }
+
+    // --- email validation tests ---
+
+    @Test
+    fun email_valid() {
+        val args = JsonObject(mapOf("value" to JsonPrimitive("test@example.com")))
+        val result = FunctionEvaluator.evaluateBoolean("email", args, emptyContext)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun email_invalid() {
+        val args = JsonObject(mapOf("value" to JsonPrimitive("not-an-email")))
+        val result = FunctionEvaluator.evaluateBoolean("email", args, emptyContext)
+        assertEquals(false, result)
+    }
+}


### PR DESCRIPTION
Replace JVM-only `Double.toBigDecimal().toPlainString()` in FunctionEvaluator.evaluateFormatNumber with a multiplatform `doubleToPlainString()` helper that handles scientific notation conversion without platform-specific APIs.

Add FunctionEvaluatorTest covering formatNumber, formatCurrency, required, and email validation functions.

https://claude.ai/code/session_01YS1c1bScVvRwDikT2xt7BT