### PR TITLE
Fix number formatting: apply grouping on fast-path and round currency cents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Chores
+- Fix `formatNumber` to apply thousands separators on the integer fast-path and `formatCurrency` to round cents instead of truncating, fixing Kotlin/Native test failures
+
 ## [0.9.0] - 2026-02-14
 
 A2UI protocol upgrade from v0.8 to v0.9. This is a **breaking release** that changes the wire format, operation names, component structure, and data binding system.

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/function/FunctionEvaluator.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/function/FunctionEvaluator.kt
@@ -224,7 +224,8 @@ object FunctionEvaluator {
 
         // Basic number formatting
         val formatted = if (maximumFractionDigits == 0 && value == value.toLong().toDouble()) {
-            value.toLong().toString()
+            val intStr = value.toLong().toString()
+            if (useGrouping) addThousandsSeparator(intStr) else intStr
         } else {
             val str = doubleToPlainString(value)
             val parts = str.split(".")
@@ -252,7 +253,7 @@ object FunctionEvaluator {
             else -> currency
         }
         val formatted = addThousandsSeparator(value.toLong().toString())
-        val cents = ((value - value.toLong()) * 100).toLong().toString().padStart(2, '0')
+        val cents = kotlin.math.round((value - value.toLong()) * 100).toLong().toString().padStart(2, '0')
         return JsonPrimitive("$symbol$formatted.$cents")
     }
 


### PR DESCRIPTION
## Summary
This PR fixes two bugs in the number formatting functions that were causing Kotlin/Native test failures.

## Key Changes
- **formatNumber**: Apply thousands separator on the integer fast-path when `useGrouping` is enabled. Previously, the fast-path for whole numbers would skip grouping entirely.
- **formatCurrency**: Use `kotlin.math.round()` when calculating cents instead of truncating, ensuring proper rounding of fractional cents (e.g., 0.999 cents rounds to 1 cent instead of being truncated to 0).

## Implementation Details
- The integer fast-path in `formatNumber` now conditionally applies `addThousandsSeparator()` based on the `useGrouping` flag
- Currency formatting now rounds the fractional part before converting to cents, preventing precision loss from truncation