### PR TITLE
Fix v0.8 Button action, source id doubling, empty-snapshot rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.2] - 2026-04-18
+## [0.9.2] - 2026-04-19
 
 ### Fixed
 - **`A2UISurface` now renders v0.8 surfaces whose root component has an id
@@ -19,12 +19,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now uses `rootComponent.id`, which respects `rootComponentId` for v0.8
   compat and falls back to the `"root"` convention for v0.9.
   ([library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt))
+- **v0.8 Button action shape is now transcoded to v0.9.** The v0.8 wire
+  format put the action payload directly on `action` as
+  `{"name": "...", "context": [{"key": "...", "value": ...}]}`; v0.9
+  wraps it in an `event` discriminator and uses a flat `context` object.
+  Because `V08ComponentFlattener` previously only unwrapped values and
+  didn't rewrite property structure, any v0.8 Button click dispatched an
+  `ActionEvent` with `name = "click"` and `context = null` — the action
+  name and bindings were silently dropped. The flattener now rewrites
+  `action` to `{"event": {"name": ..., "context": {...}}}` and converts
+  the v0.8 array-of-pairs context into a flat JSON object. Honors
+  `event` / `functionCall` when already set so native v0.9 actions pass
+  through untouched.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattener.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattener.kt))
+- **v0.8 Button `primary: true` → v0.9 `variant: "primary"`.** Added to
+  the flattener's Button-specific rewrites. An explicit `variant` takes
+  precedence over the legacy boolean.
+- **`Button.sourceComponentId` no longer double-prefixes template keys.**
+  The widget unconditionally prepended `"item"` to the template key, so
+  clicking a button inside a data map keyed `{item1: …, item5: …}`
+  produced `"btn:itemitem5"` instead of `"btn:item5"`. Now uses the key
+  verbatim.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ButtonWidget.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ButtonWidget.kt))
+- **Empty v0.8 `ACTIVITY_SNAPSHOT` envelopes now return `true` from
+  `SurfaceStateManager.processMessage`.** A snapshot with
+  `"operations": []` is a legal baseline for subsequent deltas and still
+  updates the transcoder's per-`messageId` cache; returning `false`
+  earlier mistakenly triggered "envelope rejected" diagnostics in
+  callers. `processMessage` now returns `false` only when the envelope
+  itself is unrecognized.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt))
+- **`isV08Envelope` is stricter about bare version tags.** Previously any
+  envelope with `version: "v0.8"` was treated as v0.8 even when the rest
+  of the object was a v0.9 op (`createSurface`, etc.). A version tag
+  alone no longer suffices — the envelope must carry a `type` / `kind`
+  of `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA`, or a bare `operations`
+  array. Mis-tagged v0.9 ops now correctly fall through to v0.9
+  dispatch, which rejects on version mismatch.
 
 ### Tests
 - Regression test
   `v0_8 beginRendering with non-default root id preserves rootComponentId
   and resolves rootComponent` — every existing v0.8 transcoder test used
-  `"root":"root"`, which is why this bug slipped through.
+  `"root":"root"`, which is why the renderer bug slipped through.
+- New `V08ComponentFlattenerTest` cases: v0.8 Button action with array
+  context → v0.9 event-wrapped with flat context object; v0.8 object
+  context → wrapped unchanged; already-wrapped `event` / `functionCall`
+  actions pass through; `primary: true` → `variant: "primary"`;
+  explicit `variant` beats `primary`.
+- New `SurfaceStateManagerTest` case: empty v0.8 `ACTIVITY_SNAPSHOT`
+  returns `true` and caches the baseline; a follow-up `ACTIVITY_DELTA`
+  dispatches the newly-added `beginRendering` op.
+- Updated `V08MessageTranscoderTest`: "bare version v0.8 envelope with
+  operations list is recognized", "version v0.8 without operations is
+  NOT recognized".
 
 ### Documentation
 - New `skills/migrate-0.8-to-0.9.md` — agent-agnostic migration skill for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.3] - 2026-04-19
+## [0.9.2] - 2026-04-19
 
 ### Fixed
+- **`A2UISurface` now renders v0.8 surfaces whose root component has an id
+  other than `"root"`.** Previously the renderer invoked `ComponentBuilder`
+  with a hardcoded `componentId = "root"`, ignoring `rootComponentId` even
+  though `UiDefinition.rootComponent` resolved it correctly. Any v0.8 agent
+  whose `beginRendering.root` named a custom id (e.g., `"header"`) rendered
+  as "Missing component: root" instead of the actual UI tree. The renderer
+  now uses `rootComponent.id`, which respects `rootComponentId` for v0.8
+  compat and falls back to the `"root"` convention for v0.9.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt))
 - **v0.8 Button action shape is now transcoded to v0.9.** The v0.8 wire
   format put the action payload directly on `action` as
   `{"name": "...", "context": [{"key": "...", "value": ...}]}`; v0.9
@@ -49,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatch, which rejects on version mismatch.
 
 ### Tests
+- Regression test
+  `v0_8 beginRendering with non-default root id preserves rootComponentId
+  and resolves rootComponent` — every existing v0.8 transcoder test used
+  `"root":"root"`, which is why the renderer bug slipped through.
 - New `V08ComponentFlattenerTest` cases: v0.8 Button action with array
   context → v0.9 event-wrapped with flat context object; v0.8 object
   context → wrapped unchanged; already-wrapped `event` / `functionCall`
@@ -60,25 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `V08MessageTranscoderTest`: "bare version v0.8 envelope with
   operations list is recognized", "version v0.8 without operations is
   NOT recognized".
-
-## [0.9.2] - 2026-04-18
-
-### Fixed
-- **`A2UISurface` now renders v0.8 surfaces whose root component has an id
-  other than `"root"`.** Previously the renderer invoked `ComponentBuilder`
-  with a hardcoded `componentId = "root"`, ignoring `rootComponentId` even
-  though `UiDefinition.rootComponent` resolved it correctly. Any v0.8 agent
-  whose `beginRendering.root` named a custom id (e.g., `"header"`) rendered
-  as "Missing component: root" instead of the actual UI tree. The renderer
-  now uses `rootComponent.id`, which respects `rootComponentId` for v0.8
-  compat and falls back to the `"root"` convention for v0.9.
-  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt))
-
-### Tests
-- Regression test
-  `v0_8 beginRendering with non-default root id preserves rootComponentId
-  and resolves rootComponent` — every existing v0.8 transcoder test used
-  `"root":"root"`, which is why this bug slipped through.
 
 ### Documentation
 - New `skills/migrate-0.8-to-0.9.md` — agent-agnostic migration skill for
@@ -272,8 +266,7 @@ Initial implementation of the A2UI v0.8 rendering engine.
 - Event system: UserActionEvent, DataChangeEvent
 - Kotlin Multiplatform support: Android, iOS, JVM/Desktop
 
-[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.3...HEAD
-[0.9.3]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...v0.9.3
+[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...HEAD
 [0.9.2]: https://github.com/Contextable/a2ui-4k/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Contextable/a2ui-4k/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.2] - 2026-04-19
+## [0.9.3] - 2026-04-19
 
 ### Fixed
-- **`A2UISurface` now renders v0.8 surfaces whose root component has an id
-  other than `"root"`.** Previously the renderer invoked `ComponentBuilder`
-  with a hardcoded `componentId = "root"`, ignoring `rootComponentId` even
-  though `UiDefinition.rootComponent` resolved it correctly. Any v0.8 agent
-  whose `beginRendering.root` named a custom id (e.g., `"header"`) rendered
-  as "Missing component: root" instead of the actual UI tree. The renderer
-  now uses `rootComponent.id`, which respects `rootComponentId` for v0.8
-  compat and falls back to the `"root"` convention for v0.9.
-  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt))
 - **v0.8 Button action shape is now transcoded to v0.9.** The v0.8 wire
   format put the action payload directly on `action` as
   `{"name": "...", "context": [{"key": "...", "value": ...}]}`; v0.9
@@ -58,10 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatch, which rejects on version mismatch.
 
 ### Tests
-- Regression test
-  `v0_8 beginRendering with non-default root id preserves rootComponentId
-  and resolves rootComponent` — every existing v0.8 transcoder test used
-  `"root":"root"`, which is why the renderer bug slipped through.
 - New `V08ComponentFlattenerTest` cases: v0.8 Button action with array
   context → v0.9 event-wrapped with flat context object; v0.8 object
   context → wrapped unchanged; already-wrapped `event` / `functionCall`
@@ -73,6 +60,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `V08MessageTranscoderTest`: "bare version v0.8 envelope with
   operations list is recognized", "version v0.8 without operations is
   NOT recognized".
+
+## [0.9.2] - 2026-04-18
+
+### Fixed
+- **`A2UISurface` now renders v0.8 surfaces whose root component has an id
+  other than `"root"`.** Previously the renderer invoked `ComponentBuilder`
+  with a hardcoded `componentId = "root"`, ignoring `rootComponentId` even
+  though `UiDefinition.rootComponent` resolved it correctly. Any v0.8 agent
+  whose `beginRendering.root` named a custom id (e.g., `"header"`) rendered
+  as "Missing component: root" instead of the actual UI tree. The renderer
+  now uses `rootComponent.id`, which respects `rootComponentId` for v0.8
+  compat and falls back to the `"root"` convention for v0.9.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/render/A2UiSurface.kt))
+
+### Tests
+- Regression test
+  `v0_8 beginRendering with non-default root id preserves rootComponentId
+  and resolves rootComponent` — every existing v0.8 transcoder test used
+  `"root":"root"`, which is why this bug slipped through.
 
 ### Documentation
 - New `skills/migrate-0.8-to-0.9.md` — agent-agnostic migration skill for
@@ -266,7 +272,8 @@ Initial implementation of the A2UI v0.8 rendering engine.
 - Event system: UserActionEvent, DataChangeEvent
 - Kotlin Multiplatform support: Android, iOS, JVM/Desktop
 
-[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/Contextable/a2ui-4k/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Contextable/a2ui-4k/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...v0.9.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = findProperty("publishVersion")?.toString() ?: "0.9.2"
+version = findProperty("publishVersion")?.toString() ?: "0.9.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = findProperty("publishVersion")?.toString() ?: "0.9.3"
+version = findProperty("publishVersion")?.toString() ?: "0.9.2"

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ButtonWidget.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/catalog/widgets/ButtonWidget.kt
@@ -140,8 +140,12 @@ private fun ButtonWidgetContent(
         val contextObject = eventData?.get("context") as? JsonObject
         val resolvedContext = resolveContext(contextObject, dataContext)
 
+        // Use the template key verbatim; the List widget already supplies
+        // it as the array index ("0", "1") or the object key ("item5"), so
+        // prepending "item" double-prefixes when the data map is keyed like
+        // {"item1": {...}, "item2": {...}}.
         val sourceComponentId = if (templateItemKey != null) {
-            "$componentId:item$templateItemKey"
+            "$componentId:$templateItemKey"
         } else {
             componentId
         }

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattener.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattener.kt
@@ -105,7 +105,72 @@ object V08ComponentFlattener {
         for ((key, value) in extraProps) {
             result[key] = value
         }
+
+        // Widget-specific post-passes that rewrite v0.8 prop shapes which
+        // cannot be expressed as pure value unwrapping.
+        applyWidgetSpecificRewrites(widgetType, result)
+
         return JsonObject(result)
+    }
+
+    /**
+     * In-place rewrites for widgets whose v0.8 → v0.9 delta touches property
+     * structure (not just value wrapping). Kept here rather than in
+     * `unwrapValue` because the shape change is widget-aware.
+     */
+    private fun applyWidgetSpecificRewrites(
+        widgetType: String,
+        props: MutableMap<String, JsonElement>
+    ) {
+        when (widgetType) {
+            "Button" -> rewriteButton(props)
+        }
+    }
+
+    /**
+     * v0.8 Button.action:
+     *   { "name": "submit", "context": [{"key":"k","value":{"path":"/p"}}] }
+     * v0.9 Button.action:
+     *   { "event": { "name": "submit", "context": {"k": {"path":"/p"}} } }
+     *
+     * v0.8 also used `primary: true` for button emphasis; v0.9 uses
+     * `variant: "primary"`. Do not overwrite an explicit `variant`.
+     */
+    private fun rewriteButton(props: MutableMap<String, JsonElement>) {
+        // action: rewrap as event + convert context array-of-pairs to object.
+        val action = props["action"] as? JsonObject
+        if (action != null && !action.containsKey("event") && !action.containsKey("functionCall")) {
+            val name = action["name"]
+            val contextElement = action["context"]
+            if (name != null) {
+                val contextObj: JsonElement? = when (contextElement) {
+                    is JsonArray -> {
+                        // v0.8: array of {key, value} pairs
+                        val map = mutableMapOf<String, JsonElement>()
+                        for (entry in contextElement) {
+                            val e = entry as? JsonObject ?: continue
+                            val k = (e["key"] as? JsonPrimitive)?.contentOrNull ?: continue
+                            val v = e["value"] ?: continue
+                            map[k] = v
+                        }
+                        JsonObject(map)
+                    }
+                    is JsonObject -> contextElement
+                    else -> null
+                }
+                val eventBody = buildMap<String, JsonElement> {
+                    put("name", name)
+                    if (contextObj != null) put("context", contextObj)
+                }
+                props["action"] = JsonObject(mapOf("event" to JsonObject(eventBody)))
+            }
+        }
+
+        // primary: true → variant: "primary" (unless variant is already set).
+        val primary = props["primary"] as? JsonPrimitive
+        if (primary != null && primary.contentOrNull == "true" && !props.containsKey("variant")) {
+            props["variant"] = JsonPrimitive("primary")
+        }
     }
 
     /**

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08MessageTranscoder.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/protocol/v08/V08MessageTranscoder.kt
@@ -61,7 +61,11 @@ class V08MessageTranscoder {
     fun isV08Envelope(envelope: JsonObject): Boolean {
         if ((envelope["kind"] as? JsonPrimitive)?.contentOrNull in V08_ENVELOPE_KINDS) return true
         if ((envelope["type"] as? JsonPrimitive)?.contentOrNull in V08_ENVELOPE_KINDS) return true
-        if ((envelope["version"] as? JsonPrimitive)?.contentOrNull == A2UIExtension.PROTOCOL_VERSION_V08) return true
+        // Bare v0.8 envelope (no ACTIVITY_* wrapper) — accepted only if it
+        // also carries the snapshot-style `operations` array. A version tag
+        // alone on a v0.9-shaped op is a version mismatch, not a v0.8 msg.
+        if ((envelope["version"] as? JsonPrimitive)?.contentOrNull == A2UIExtension.PROTOCOL_VERSION_V08
+            && envelope.containsKey("operations")) return true
         return false
     }
 

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt
@@ -95,21 +95,23 @@ class SurfaceStateManager {
      * - v0.8 `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` envelope (transcoded
      *   internally to v0.9)
      *
-     * Returns `true` if the message was recognized and dispatched, `false`
-     * if it was ignored (wrong version, unknown op, etc.). A single v0.8
-     * envelope may dispatch multiple underlying operations — in that case
-     * returns `true` if any of them were recognized.
+     * Returns `true` if the message was recognized (and dispatched, when
+     * applicable); `false` only when the envelope was not a shape this
+     * manager understands. A legal-but-empty v0.8 envelope — an
+     * `ACTIVITY_SNAPSHOT` with `operations: []` or an `ACTIVITY_DELTA`
+     * whose patch produces no new operations — still returns `true`: the
+     * transcoder's per-`messageId` cache is updated so later deltas can
+     * replay against it. Callers should treat `false` as a genuine
+     * unrecognized-envelope signal, not as "nothing happened".
      */
     fun processMessage(message: JsonObject): Boolean {
         // v0.8 dispatch: transcode to v0.9 shape, then recurse per transcoded op.
         if (v08Transcoder.isV08Envelope(message)) {
             val transcoded = v08Transcoder.transcode(message)
-            if (transcoded.isEmpty()) return false
-            var any = false
             for (sub in transcoded) {
-                if (processV09Message(sub, ProtocolVersion.V0_8)) any = true
+                processV09Message(sub, ProtocolVersion.V0_8)
             }
-            return any
+            return true
         }
         return processV09Message(message, ProtocolVersion.V0_9)
     }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattenerTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/protocol/v08/V08ComponentFlattenerTest.kt
@@ -141,10 +141,38 @@ class V08ComponentFlattenerTest {
         assertEquals("mutuallyExclusive", (out["variant"] as JsonPrimitive).content)
     }
 
-    // --- nested unwrapping (e.g. action.context) ---
+    // --- Button action rewrites (v0.8 shape → v0.9 event/functionCall wrapper) ---
 
     @Test
-    fun `nested action context is recursively unwrapped`() {
+    fun `v0_8 Button action with array context is wrapped in event and flattened`() {
+        val out = V08ComponentFlattener.flatten(
+            obj("""
+                {
+                    "id":"btn",
+                    "component":{"Button":{
+                        "action":{
+                            "name":"book_restaurant",
+                            "context":[
+                                {"key":"restaurantName","value":{"path":"name"}},
+                                {"key":"address","value":{"path":"address"}}
+                            ]
+                        }
+                    }}
+                }
+            """.trimIndent())
+        )
+        val action = out["action"] as JsonObject
+        val event = action["event"] as JsonObject
+        assertEquals("book_restaurant", (event["name"] as JsonPrimitive).content)
+        val context = event["context"] as JsonObject
+        val name = context["restaurantName"] as JsonObject
+        assertEquals("name", (name["path"] as JsonPrimitive).content)
+        val address = context["address"] as JsonObject
+        assertEquals("address", (address["path"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `v0_8 Button action with object context is wrapped in event without reshaping context`() {
         val out = V08ComponentFlattener.flatten(
             obj("""
                 {
@@ -162,8 +190,60 @@ class V08ComponentFlattenerTest {
             """.trimIndent())
         )
         val action = out["action"] as JsonObject
-        val context = action["context"] as JsonObject
+        val event = action["event"] as JsonObject
+        assertEquals("submit", (event["name"] as JsonPrimitive).content)
+        val context = event["context"] as JsonObject
         assertEquals("123", (context["orderId"] as JsonPrimitive).content)
         assertEquals(JsonPrimitive(42), context["amount"])
+    }
+
+    @Test
+    fun `v0_9 Button action with existing event wrapper is left alone`() {
+        val out = V08ComponentFlattener.flatten(
+            obj("""
+                {
+                    "id":"btn",
+                    "component":{"Button":{
+                        "action":{"event":{"name":"go","context":{"k":"v"}}}
+                    }}
+                }
+            """.trimIndent())
+        )
+        val action = out["action"] as JsonObject
+        val event = action["event"] as JsonObject
+        assertEquals("go", (event["name"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `v0_9 Button action with functionCall is left alone`() {
+        val out = V08ComponentFlattener.flatten(
+            obj("""
+                {
+                    "id":"btn",
+                    "component":{"Button":{
+                        "action":{"functionCall":{"call":"openUrl","args":{"u":"x"}}}
+                    }}
+                }
+            """.trimIndent())
+        )
+        val action = out["action"] as JsonObject
+        assertEquals(true, action.containsKey("functionCall"))
+        assertEquals(false, action.containsKey("event"))
+    }
+
+    @Test
+    fun `v0_8 Button primary boolean becomes variant primary`() {
+        val out = V08ComponentFlattener.flatten(
+            obj("""{"id":"b","component":{"Button":{"primary":{"literalBoolean":true}}}}""")
+        )
+        assertEquals("primary", (out["variant"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `Button explicit variant wins over primary boolean`() {
+        val out = V08ComponentFlattener.flatten(
+            obj("""{"id":"b","component":{"Button":{"variant":{"literalString":"borderless"},"primary":{"literalBoolean":true}}}}""")
+        )
+        assertEquals("borderless", (out["variant"] as JsonPrimitive).content)
     }
 }

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/protocol/v08/V08MessageTranscoderTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/protocol/v08/V08MessageTranscoderTest.kt
@@ -49,9 +49,18 @@ class V08MessageTranscoderTest {
     }
 
     @Test
-    fun `version v08 recognized as v08`() {
+    fun `bare version v08 envelope with operations list is recognized as v08`() {
         val t = V08MessageTranscoder()
-        assertTrue(t.isV08Envelope(obj("""{"version":"v0.8","createSurface":{}}""")))
+        assertTrue(t.isV08Envelope(obj("""{"version":"v0.8","operations":[]}""")))
+    }
+
+    @Test
+    fun `version v08 without operations is NOT recognized as v08`() {
+        // A v0.9-shaped op mis-tagged with version "v0.8" must not be treated
+        // as a v0.8 message. The op-key shape (createSurface etc.) belongs to
+        // v0.9; let processMessage fall through and reject on version mismatch.
+        val t = V08MessageTranscoder()
+        assertFalse(t.isV08Envelope(obj("""{"version":"v0.8","createSurface":{}}""")))
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/state/SurfaceStateManagerTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/state/SurfaceStateManagerTest.kt
@@ -468,6 +468,32 @@ class SurfaceStateManagerTest {
     }
 
     @Test
+    fun `empty v0_8 ACTIVITY_SNAPSHOT returns true and caches the baseline for deltas`() {
+        // Regression: processMessage used to return false on a legal-but-empty
+        // v0.8 snapshot, tricking callers into logging "envelope rejected".
+        // Empty snapshots are valid — they just establish the per-messageId
+        // baseline for subsequent deltas.
+        val manager = SurfaceStateManager()
+        val emptySnapshot: JsonObject = json.decodeFromString(
+            """{"type":"ACTIVITY_SNAPSHOT","messageId":"m1","content":{"operations":[]}}"""
+        )
+        assertTrue(manager.processMessage(emptySnapshot))
+
+        // The subsequent delta adds a real beginRendering op and must succeed.
+        val delta: JsonObject = json.decodeFromString(
+            """
+            {"type":"ACTIVITY_DELTA","messageId":"m1","patch":[
+                {"op":"add","path":"/operations/-","value":
+                    {"beginRendering":{"surfaceId":"s1","root":"root"}}
+                }
+            ]}
+            """.trimIndent()
+        )
+        assertTrue(manager.processMessage(delta))
+        assertNotNull(manager.getSurface("s1"))
+    }
+
+    @Test
     fun `v0_8 and v0_9 surfaces coexist and carry different protocolVersion`() {
         val manager = SurfaceStateManager()
         // v0.9 surface


### PR DESCRIPTION
## Summary
Three v0.8 compat bugs uncovered when running the migrated client against a legacy A2UI agent. All net changes are in commit `084d52e`; the branch also contains a `Bump to 0.9.3` and immediate `Roll back 0.9.3 bump` pair that cancel out, so the version stays at `0.9.2` and these fixes ship as `0.9.2-beta.<n>`.

- **V08ComponentFlattener now rewrites `Button.action`.** v0.8 ships `{name, context:[{key,value}]}` directly on action; v0.9 wraps it under an event discriminator with a flat context object. Every v0.8 button click was dispatching `ActionEvent(name="click", context=null)` and silently dropping the agent-specified action + bindings. The flattener now converts the shape and walks the context array into a flat object, honoring pre-set `event`/`functionCall` so native v0.9 actions pass through. Also maps legacy `Button.primary:true` → `variant:"primary"`.
- **`ButtonWidget.sourceComponentId` no longer double-prefixes `item`.** For data keyed `{item1, item5, ...}` it was producing `"btn:itemitem5"` — now uses the key verbatim.
- **`SurfaceStateManager.processMessage` accepts empty v0.8 `ACTIVITY_SNAPSHOT` envelopes.** Empty baselines were returning `false`, prompting bridge code to log `\"envelope rejected\"` for what is actually a legal v0.8 message. `false` is now reserved for unrecognized shapes. `isV08Envelope` tightened so a bare version tag on a v0.9-shaped op is no longer misclassified as v0.8.

## Test plan
- [x] CI green (`./gradlew :a2ui-4k:allTests`)
- [x] V08ComponentFlattenerTest covers the new Button.action rewrite + primary→variant mapping
- [x] V08MessageTranscoderTest covers the tightened isV08Envelope discrimination
- [x] SurfaceStateManagerTest covers empty ACTIVITY_SNAPSHOT acceptance
- [x] Manual: legacy v0.8 agent button click dispatches the agent-specified action with bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)