### PR TITLE
Bump to 0.9.3: add canonical render_a2ui tool helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-04-21
+
+### Added
+- **`A2UiRenderTool`** in new `com.contextable.a2ui4k.agent` package — a
+  transport-agnostic, SDK-agnostic helper that packages the canonical
+  `createSurface` + `updateComponents` + optional `updateDataModel` flow
+  behind a single `render(JsonObject): JsonObject` call. Ships tool
+  `name`, `description`, and JSON-Schema `parameters` ready to plug into
+  any agent tool-calling SDK (AG-UI Kotlin, Gemini, OpenAI, Anthropic)
+  via a ~4-line consumer adapter. Replaces bespoke `ACTIVITY_SNAPSHOT`
+  handlers that call `SurfaceStateManager.processMessage` directly,
+  closing the tool-result round-trip so ag_ui_adk's HITL loop resumes
+  cleanly. No new dependencies; the library remains transport-agnostic.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt))
+- **`A2UiRenderException`** (same package) — public typed exception with
+  a structured `ValidationCode` enum and `field` name, thrown by
+  `A2UiRenderTool.render` on malformed tool-call arguments. Consumer
+  adapters catch it and map to their SDK's native failure result.
+- **`A2UIExtension.BASIC_CATALOG_URI_V09`** constant
+  (`https://a2ui.org/specification/v0_9/basic_catalog.json`) and
+  corresponding `SurfaceStateManager.processMessage` branch-match.
+  Agents that emit the `a2ui.org` URI now resolve cleanly to
+  `ProtocolVersion.V0_9`, alongside the existing `STANDARD_CATALOG_URI`.
+  ([library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt](library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt))
+
 ## [0.9.2] - 2026-04-19
 
 ### Fixed
@@ -266,7 +291,8 @@ Initial implementation of the A2UI v0.8 rendering engine.
 - Event system: UserActionEvent, DataChangeEvent
 - Kotlin Multiplatform support: Android, iOS, JVM/Desktop
 
-[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/Contextable/a2ui-4k/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/Contextable/a2ui-4k/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/Contextable/a2ui-4k/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Contextable/a2ui-4k/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Contextable/a2ui-4k/compare/v0.8.2...v0.9.0

--- a/README.md
+++ b/README.md
@@ -44,6 +44,41 @@ fun MyScreen(uiDefinition: UiDefinition) {
 
 a2ui-4k implements the [A2UI specification](https://github.com/google/A2UI) from Google. For protocol details including message formats, component properties, and data binding, refer to the canonical specification.
 
+## Exposing rendering to an agent
+
+If your agent can call client-side tools (AG-UI `ToolExecutor`, OpenAI
+functions, Gemini tools, Anthropic `tool_use`), the library ships
+`A2UiRenderTool` — a canonical, SDK-agnostic helper that maps one `render_a2ui`
+tool call to `createSurface` + `updateComponents` + optional `updateDataModel`
+on your `SurfaceStateManager`. No new dependencies; the library stays
+transport-free.
+
+```kotlin
+import com.contextable.a2ui4k.agent.A2UiRenderTool
+import com.contextable.a2ui4k.agent.A2UiRenderException
+import com.contextable.a2ui4k.state.SurfaceStateManager
+
+val manager = SurfaceStateManager()
+val renderTool = A2UiRenderTool(manager)
+
+// AG-UI Kotlin SDK adapter (~4 lines):
+class RenderA2UiToolExecutor(private val tool: A2UiRenderTool) : ToolExecutor {
+    override val name = tool.name
+    override val description = tool.description
+    override val parameters = tool.parameters
+    override suspend fun execute(arguments: JsonObject) = try {
+        ToolExecutionResult.success(tool.render(arguments).toString())
+    } catch (e: A2UiRenderException) {
+        ToolExecutionResult.failure(e.message ?: "render_a2ui failed")
+    }
+}
+
+toolRegistry.registerTool(RenderA2UiToolExecutor(renderTool))
+```
+
+See [skills/expose-a2ui-as-agent-tool.md](skills/expose-a2ui-as-agent-tool.md)
+for the full integration walkthrough and adapter snippets for other SDKs.
+
 ## Transport Integration
 
 a2ui-4k is a **rendering engine, not an A2A SDK**. It is transport-agnostic and expects callers to plug it into an A2A (Agent-to-Agent) transport of their choice. Concretely, callers are responsible for:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,4 @@ plugins {
 }
 
 group = "com.contextable"
-version = findProperty("publishVersion")?.toString() ?: "0.9.2"
+version = findProperty("publishVersion")?.toString() ?: "0.9.3"

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2025 Contextable LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.contextable.a2ui4k.agent
+
+import com.contextable.a2ui4k.extension.A2UIExtension
+import com.contextable.a2ui4k.state.SurfaceStateManager
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Canonical, transport-agnostic helper for the `render_a2ui` client-side tool.
+ *
+ * ## Intent
+ *
+ * Client apps that expose a2ui-4k's rendering engine to an agent as a
+ * server-callable tool (AG-UI `ToolExecutor`, OpenAI function-calling, Gemini
+ * tools, Anthropic `tool_use`, …) all end up doing the same three things:
+ * extract `surfaceId`/`catalogId`/`components`/`data` out of the tool
+ * arguments, feed three `processMessage` envelopes to a [SurfaceStateManager],
+ * and return a success payload. This class packages that flow once.
+ *
+ * ## What this class does NOT do
+ *
+ * - It does not implement any SDK's `ToolExecutor` interface — that lives in
+ *   consumer code so this library stays transport-free.
+ * - It does no I/O, suspends no coroutines, and touches no threading.
+ * - It does not deeply validate component JSON beyond "array shape". The
+ *   surface state manager and widget parsers do their own downstream
+ *   validation.
+ *
+ * ## Typical consumer adapter (AG-UI Kotlin SDK — ~4 lines)
+ *
+ * ```kotlin
+ * class RenderA2UiToolExecutor(private val tool: A2UiRenderTool) : ToolExecutor {
+ *     override val name = tool.name
+ *     override val description = tool.description
+ *     override val parameters = tool.parameters
+ *     override suspend fun execute(arguments: JsonObject) = try {
+ *         ToolExecutionResult.success(tool.render(arguments).toString())
+ *     } catch (e: A2UiRenderException) {
+ *         ToolExecutionResult.failure(e.message ?: "render_a2ui failed")
+ *     }
+ * }
+ * ```
+ *
+ * @param surfaceStateManager the [SurfaceStateManager] instance the renderer
+ *   reads from. Must be the same instance the Compose `A2UISurface` composable
+ *   is bound to, otherwise rendered surfaces go into a different state store
+ *   and never appear on screen.
+ * @param description human-readable tool description the LLM reads when
+ *   deciding whether to call the tool. Overridable; defaults to
+ *   [DEFAULT_DESCRIPTION].
+ */
+class A2UiRenderTool(
+    private val surfaceStateManager: SurfaceStateManager,
+    val description: String = DEFAULT_DESCRIPTION,
+) {
+    /** Canonical tool name. Matches the React ecosystem (`@copilotkit/a2ui-renderer`). */
+    val name: String = TOOL_NAME
+
+    /** JSON Schema (OpenAI / Gemini function-calling compatible). */
+    val parameters: JsonObject = DEFAULT_PARAMETERS
+
+    /**
+     * Drives [surfaceStateManager] through createSurface → updateComponents →
+     * (optional) updateDataModel, using the A2UI v0.9 wire envelope.
+     *
+     * @param arguments tool-call arguments object — see [parameters] for the
+     *   schema. The agent is expected to have conformed to that schema, but
+     *   this method defends against missing / wrong-typed fields by throwing
+     *   [A2UiRenderException] rather than silently emitting a half-rendered
+     *   surface.
+     * @return `{"status":"rendered","surfaceId":"<id>"}`. Consumer adapters
+     *   typically `.toString()` this for their SDK's string-valued tool
+     *   result.
+     * @throws A2UiRenderException if `surfaceId` or `components` is missing
+     *   or wrong-typed.
+     */
+    fun render(arguments: JsonObject): JsonObject {
+        val surfaceId = requireStringField(arguments, "surfaceId")
+        val catalogId = optionalStringField(arguments, "catalogId") ?: DEFAULT_CATALOG_ID
+        val components = arguments["components"].let {
+            when {
+                it == null -> throw A2UiRenderException(
+                    A2UiRenderException.ValidationCode.MISSING_REQUIRED_FIELD,
+                    "components",
+                    "render_a2ui: 'components' is required",
+                )
+                it !is JsonArray -> throw A2UiRenderException(
+                    A2UiRenderException.ValidationCode.WRONG_TYPE,
+                    "components",
+                    "render_a2ui: 'components' must be a JSON array",
+                )
+                else -> it
+            }
+        }
+        // 'data' is typed as object in the schema; a non-object value (array,
+        // primitive, null) is treated as "no data model update" rather than a
+        // hard error — agents sometimes send `data: null` instead of omitting.
+        val data = arguments["data"] as? JsonObject
+
+        surfaceStateManager.processMessage(
+            buildJsonObject {
+                put("version", JsonPrimitive(SurfaceStateManager.PROTOCOL_VERSION))
+                put("createSurface", buildJsonObject {
+                    put("surfaceId", JsonPrimitive(surfaceId))
+                    put("catalogId", JsonPrimitive(catalogId))
+                })
+            }
+        )
+        surfaceStateManager.processMessage(
+            buildJsonObject {
+                put("version", JsonPrimitive(SurfaceStateManager.PROTOCOL_VERSION))
+                put("updateComponents", buildJsonObject {
+                    put("surfaceId", JsonPrimitive(surfaceId))
+                    put("components", components)
+                })
+            }
+        )
+        if (data != null) {
+            surfaceStateManager.processMessage(
+                buildJsonObject {
+                    put("version", JsonPrimitive(SurfaceStateManager.PROTOCOL_VERSION))
+                    put("updateDataModel", buildJsonObject {
+                        put("surfaceId", JsonPrimitive(surfaceId))
+                        put("path", JsonPrimitive("/"))
+                        put("value", data)
+                    })
+                }
+            )
+        }
+
+        return buildJsonObject {
+            put("status", JsonPrimitive("rendered"))
+            put("surfaceId", JsonPrimitive(surfaceId))
+        }
+    }
+
+    private fun requireStringField(args: JsonObject, field: String): String {
+        val raw = args[field] ?: throw A2UiRenderException(
+            A2UiRenderException.ValidationCode.MISSING_REQUIRED_FIELD,
+            field,
+            "render_a2ui: '$field' is required",
+        )
+        val prim = raw as? JsonPrimitive
+        if (prim == null || !prim.isString) {
+            throw A2UiRenderException(
+                A2UiRenderException.ValidationCode.WRONG_TYPE,
+                field,
+                "render_a2ui: '$field' must be a string",
+            )
+        }
+        if (prim.content.isBlank()) {
+            throw A2UiRenderException(
+                A2UiRenderException.ValidationCode.EMPTY_VALUE,
+                field,
+                "render_a2ui: '$field' must not be blank",
+            )
+        }
+        return prim.content
+    }
+
+    private fun optionalStringField(args: JsonObject, field: String): String? {
+        val prim = args[field] as? JsonPrimitive ?: return null
+        return if (prim.isString) prim.content else null
+    }
+
+    companion object {
+        /** Canonical tool name. */
+        const val TOOL_NAME: String = "render_a2ui"
+
+        /**
+         * Default [catalogId] used when the tool call omits it. Set to
+         * [A2UIExtension.STANDARD_CATALOG_URI]; [A2UIExtension.BASIC_CATALOG_URI_V09]
+         * is also accepted on inbound envelopes (see
+         * [SurfaceStateManager.processMessage]).
+         */
+        const val DEFAULT_CATALOG_ID: String = A2UIExtension.STANDARD_CATALOG_URI
+
+        internal val DEFAULT_DESCRIPTION: String = """
+            Renders an A2UI v0.9 surface on the client. A2UI is a declarative UI
+            protocol: the server sends a component tree and (optionally) an initial
+            data model, and the client renders a native UI that streams user events
+            (button clicks, form input, data changes) back to the server.
+
+            Arguments:
+            - surfaceId (string, required): stable identifier for this surface.
+              Reuse the same surfaceId to update an existing surface in place —
+              components with matching ids are replaced, new components are added,
+              unmentioned components are left untouched. Use a new surfaceId to
+              create a separate, independently-rendered surface.
+            - catalogId (string, optional): URI of the component catalog. Defaults
+              to the A2UI v0.9 standard catalog. Only override if rendering from a
+              custom catalog.
+            - components (array, required): flat list of component objects, each
+              shaped { "id": "<unique-id>", "component": "<WidgetType>", ...props }.
+              The root component MUST have id "root". Container widgets (Column,
+              Row, List, Card, Tabs) reference children by id via a "children"
+              array. Literal values are plain JSON ("hello", 42, true); data
+              bindings are { "path": "/pointer" }; function calls are
+              { "call": "fnName", "args": {...} }.
+            - data (object, optional): initial data model for this surface, merged
+              at path "/". Paths referenced by component data bindings resolve
+              against this model. Omit if components are fully literal.
+
+            Returns { "status": "rendered", "surfaceId": "<id>" } on success.
+        """.trimIndent()
+
+        internal val DEFAULT_PARAMETERS: JsonObject = buildJsonObject {
+            put("type", JsonPrimitive("object"))
+            put("properties", buildJsonObject {
+                put("surfaceId", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                    put(
+                        "description",
+                        JsonPrimitive(
+                            "Stable identifier. Reuse to update in place; use a new value to create a separate surface."
+                        )
+                    )
+                })
+                put("catalogId", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                    put(
+                        "description",
+                        JsonPrimitive(
+                            "URI of the component catalog. Defaults to the A2UI v0.9 standard catalog."
+                        )
+                    )
+                    put("default", JsonPrimitive(DEFAULT_CATALOG_ID))
+                })
+                put("components", buildJsonObject {
+                    put("type", JsonPrimitive("array"))
+                    put(
+                        "description",
+                        JsonPrimitive(
+                            "Flat list of A2UI component objects. The root must have id 'root'."
+                        )
+                    )
+                    put("items", buildJsonObject {
+                        put("type", JsonPrimitive("object"))
+                        put("required", buildJsonArray {
+                            add(JsonPrimitive("id"))
+                            add(JsonPrimitive("component"))
+                        })
+                        put("properties", buildJsonObject {
+                            put("id", buildJsonObject { put("type", JsonPrimitive("string")) })
+                            put("component", buildJsonObject { put("type", JsonPrimitive("string")) })
+                        })
+                        // Widget props vary by component — leave the item schema open.
+                        put("additionalProperties", JsonPrimitive(true))
+                    })
+                })
+                put("data", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put(
+                        "description",
+                        JsonPrimitive(
+                            "Optional initial data model, merged at path '/'. Referenced by component data bindings of the form {\"path\": \"/...\"}."
+                        )
+                    )
+                    put("additionalProperties", JsonPrimitive(true))
+                })
+            })
+            put("required", buildJsonArray {
+                add(JsonPrimitive("surfaceId"))
+                add(JsonPrimitive("components"))
+            })
+            // Block LLMs from inventing extra top-level fields — only the four
+            // above are meaningful.
+            put("additionalProperties", JsonPrimitive(false))
+        }
+    }
+}
+
+/**
+ * Thrown by [A2UiRenderTool.render] when tool-call arguments are missing or
+ * wrong-typed. Carries a structured [code] + [field] so consumer adapters can
+ * surface the human-readable [message] to the LLM and log the structured
+ * cause separately.
+ *
+ * Extends [IllegalArgumentException] so callers that don't catch it get a
+ * sensible default error.
+ */
+class A2UiRenderException(
+    val code: ValidationCode,
+    val field: String,
+    message: String,
+) : IllegalArgumentException(message) {
+
+    /** Machine-readable cause, for structured logging / adapter branching. */
+    enum class ValidationCode {
+        /** The field was absent from the arguments object. */
+        MISSING_REQUIRED_FIELD,
+
+        /** The field was present but of the wrong JSON type. */
+        WRONG_TYPE,
+
+        /** The field was present, the right type, but blank/empty. */
+        EMPTY_VALUE,
+    }
+}

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt
@@ -43,6 +43,15 @@ object A2UIExtension {
     const val STANDARD_CATALOG_URI = "https://github.com/google/A2UI/blob/main/specification/v0_9/json/standard_catalog.json"
 
     /**
+     * Alternate v0.9 catalog URI emitted by parts of the ecosystem (notably
+     * `@copilotkit/a2ui-middleware` and `google/A2UI` sample agents). Wire-
+     * compatible with [STANDARD_CATALOG_URI] — [com.contextable.a2ui4k.state.SurfaceStateManager]
+     * treats either as a v0.9 signal when resolving a surface's protocol
+     * version.
+     */
+    const val BASIC_CATALOG_URI_V09 = "https://a2ui.org/specification/v0_9/basic_catalog.json"
+
+    /**
      * The URI of the standard A2UI v0.8 component catalog definition. Clients
      * that want to negotiate down to v0.8 when talking to legacy agents should
      * include this in `a2uiClientCapabilities.supportedCatalogIds`.

--- a/library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt
+++ b/library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt
@@ -167,7 +167,8 @@ class SurfaceStateManager {
         // version — but normally they agree.
         val version = when (catalogId) {
             A2UIExtension.STANDARD_CATALOG_URI_V08 -> ProtocolVersion.V0_8
-            A2UIExtension.STANDARD_CATALOG_URI -> ProtocolVersion.V0_9
+            A2UIExtension.STANDARD_CATALOG_URI,
+            A2UIExtension.BASIC_CATALOG_URI_V09 -> ProtocolVersion.V0_9
             else -> sourceVersion
         }
 

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/agent/A2UiRenderToolTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/agent/A2UiRenderToolTest.kt
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2025 Contextable LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.contextable.a2ui4k.agent
+
+import com.contextable.a2ui4k.extension.A2UIExtension
+import com.contextable.a2ui4k.model.ProtocolVersion
+import com.contextable.a2ui4k.state.SurfaceStateManager
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [A2UiRenderTool], the canonical client-side `render_a2ui` helper
+ * that drives a [SurfaceStateManager] from a single tool-call argument
+ * object.
+ */
+class A2UiRenderToolTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun args(body: String): JsonObject = json.decodeFromString(body)
+
+    // --- happy paths ---
+
+    @Test
+    fun `happy path renders surface with components and data`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val result = tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s1",
+                    "catalogId":"${A2UIExtension.STANDARD_CATALOG_URI}",
+                    "components":[
+                        {"id":"root","component":"Column","children":["title"]},
+                        {"id":"title","component":"Text","text":"Hello"}
+                    ],
+                    "data":{"user":{"name":"Alice"}}
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals("rendered", (result["status"] as? JsonPrimitive)?.content)
+        assertEquals("s1", (result["surfaceId"] as? JsonPrimitive)?.content)
+
+        val surface = manager.getSurface("s1")
+        assertNotNull(surface)
+        assertEquals(A2UIExtension.STANDARD_CATALOG_URI, surface.catalogId)
+        assertEquals(2, surface.components.size)
+        assertEquals("Column", surface.components["root"]?.widgetType)
+        assertEquals("Text", surface.components["title"]?.widgetType)
+
+        assertEquals("Alice", manager.getDataModel("s1")?.getString("/user/name"))
+    }
+
+    @Test
+    fun `render without data still creates surface and components`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s2",
+                    "components":[
+                        {"id":"root","component":"Text","text":"Hi"}
+                    ]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val surface = manager.getSurface("s2")
+        assertNotNull(surface)
+        assertEquals(1, surface.components.size)
+        // No data was written.
+        assertNull(manager.getDataModel("s2")?.getString("/user/name"))
+    }
+
+    // --- catalogId handling ---
+
+    @Test
+    fun `explicit catalogId overrides default`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s3",
+                    "catalogId":"https://example.com/custom.json",
+                    "components":[{"id":"root","component":"Text","text":"X"}]
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals("https://example.com/custom.json", manager.getSurface("s3")?.catalogId)
+    }
+
+    @Test
+    fun `omitted catalogId uses DEFAULT_CATALOG_ID`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s4",
+                    "components":[{"id":"root","component":"Text","text":"X"}]
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals(A2UIExtension.STANDARD_CATALOG_URI, A2UiRenderTool.DEFAULT_CATALOG_ID)
+        assertEquals(A2UIExtension.STANDARD_CATALOG_URI, manager.getSurface("s4")?.catalogId)
+    }
+
+    // --- validation errors ---
+
+    @Test
+    fun `missing surfaceId throws with MISSING_REQUIRED_FIELD and field surfaceId`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val ex = assertFailsWith<A2UiRenderException> {
+            tool.render(args("""{"components":[]}"""))
+        }
+        assertEquals(A2UiRenderException.ValidationCode.MISSING_REQUIRED_FIELD, ex.code)
+        assertEquals("surfaceId", ex.field)
+        // Nothing landed in the manager.
+        assertEquals(0, manager.surfaceCount)
+    }
+
+    @Test
+    fun `missing components throws with MISSING_REQUIRED_FIELD and field components`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val ex = assertFailsWith<A2UiRenderException> {
+            tool.render(args("""{"surfaceId":"s"}"""))
+        }
+        assertEquals(A2UiRenderException.ValidationCode.MISSING_REQUIRED_FIELD, ex.code)
+        assertEquals("components", ex.field)
+    }
+
+    @Test
+    fun `non-string surfaceId throws with WRONG_TYPE`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val ex = assertFailsWith<A2UiRenderException> {
+            tool.render(args("""{"surfaceId":42,"components":[]}"""))
+        }
+        assertEquals(A2UiRenderException.ValidationCode.WRONG_TYPE, ex.code)
+        assertEquals("surfaceId", ex.field)
+    }
+
+    @Test
+    fun `non-array components throws with WRONG_TYPE`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val ex = assertFailsWith<A2UiRenderException> {
+            tool.render(args("""{"surfaceId":"s","components":{}}"""))
+        }
+        assertEquals(A2UiRenderException.ValidationCode.WRONG_TYPE, ex.code)
+        assertEquals("components", ex.field)
+    }
+
+    @Test
+    fun `blank surfaceId throws with EMPTY_VALUE`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        val ex = assertFailsWith<A2UiRenderException> {
+            tool.render(args("""{"surfaceId":"  ","components":[]}"""))
+        }
+        assertEquals(A2UiRenderException.ValidationCode.EMPTY_VALUE, ex.code)
+        assertEquals("surfaceId", ex.field)
+    }
+
+    // --- edge cases ---
+
+    @Test
+    fun `non-object data is silently ignored`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s5",
+                    "components":[{"id":"root","component":"Text","text":"X"}],
+                    "data":[1,2,3]
+                }
+                """.trimIndent()
+            )
+        )
+
+        // Surface exists, but data model was never populated from the array.
+        val surface = manager.getSurface("s5")
+        assertNotNull(surface)
+        val dm = manager.getDataModel("s5")
+        assertNotNull(dm)
+        assertNull(dm.get("/0"))
+    }
+
+    @Test
+    fun `repeated render into same surfaceId merges components`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s6",
+                    "components":[{"id":"root","component":"Text","text":"First"}]
+                }
+                """.trimIndent()
+            )
+        )
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s6",
+                    "components":[{"id":"root","component":"Text","text":"Second"}]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val root = manager.getSurface("s6")?.components?.get("root")
+        assertNotNull(root)
+        assertEquals("Second", (root.widgetData["text"] as? JsonPrimitive)?.content)
+        assertEquals(1, manager.surfaceCount)
+    }
+
+    @Test
+    fun `render passes v0_9 envelopes so manager tags surface as V0_9`() {
+        val manager = SurfaceStateManager()
+        val tool = A2UiRenderTool(manager)
+
+        tool.render(
+            args(
+                """
+                {
+                    "surfaceId":"s7",
+                    "components":[{"id":"root","component":"Text","text":"X"}]
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals(ProtocolVersion.V0_9, manager.getSurfaceProtocolVersion("s7"))
+    }
+
+    // --- schema / description smoke ---
+
+    @Test
+    fun `description and parameters are non-empty and structured correctly`() {
+        val tool = A2UiRenderTool(SurfaceStateManager())
+
+        assertEquals("render_a2ui", tool.name)
+        assertTrue(tool.description.isNotBlank())
+
+        val params = tool.parameters
+        assertEquals("object", (params["type"] as? JsonPrimitive)?.content)
+
+        val required = params["required"] as? JsonArray
+        assertNotNull(required)
+        val requiredNames = required.mapNotNull { (it as? JsonPrimitive)?.content }.toSet()
+        assertTrue(requiredNames.containsAll(setOf("surfaceId", "components")))
+
+        assertEquals(false, (params["additionalProperties"] as? JsonPrimitive)?.content?.toBoolean())
+    }
+
+    @Test
+    fun `custom description override is exposed`() {
+        val tool = A2UiRenderTool(SurfaceStateManager(), description = "custom text")
+        assertEquals("custom text", tool.description)
+    }
+
+    @Test
+    fun `A2UiRenderException carries structured code and field`() {
+        val ex = A2UiRenderException(
+            A2UiRenderException.ValidationCode.WRONG_TYPE,
+            "surfaceId",
+            "test message",
+        )
+        assertEquals(A2UiRenderException.ValidationCode.WRONG_TYPE, ex.code)
+        assertEquals("surfaceId", ex.field)
+        assertEquals("test message", ex.message)
+    }
+
+    // --- schema boolean sanity (`assertFalse` to catch accidental inversion) ---
+
+    @Test
+    fun `top-level additionalProperties is false to block unknown fields`() {
+        val tool = A2UiRenderTool(SurfaceStateManager())
+        val additional = (tool.parameters["additionalProperties"] as? JsonPrimitive)?.content
+        assertFalse(additional?.toBoolean() ?: true)
+    }
+}

--- a/library/src/commonTest/kotlin/com/contextable/a2ui4k/state/SurfaceStateManagerTest.kt
+++ b/library/src/commonTest/kotlin/com/contextable/a2ui4k/state/SurfaceStateManagerTest.kt
@@ -16,6 +16,7 @@
 
 package com.contextable.a2ui4k.state
 
+import com.contextable.a2ui4k.extension.A2UIExtension
 import com.contextable.a2ui4k.model.ProtocolVersion
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -121,6 +122,18 @@ class SurfaceStateManagerTest {
         assertTrue(surface.sendDataModel)
         assertNotNull(surface.theme)
         assertEquals("#FF0000", (surface.theme!!["primaryColor"] as? JsonPrimitive)?.content)
+    }
+
+    @Test
+    fun `createSurface with BASIC_CATALOG_URI_V09 resolves to ProtocolVersion V0_9`() {
+        val manager = SurfaceStateManager()
+        manager.processMessage(
+            envelope(
+                "createSurface",
+                """{"surfaceId":"s","catalogId":"${A2UIExtension.BASIC_CATALOG_URI_V09}"}"""
+            )
+        )
+        assertEquals(ProtocolVersion.V0_9, manager.getSurfaceProtocolVersion("s"))
     }
 
     @Test

--- a/skills/expose-a2ui-as-agent-tool.md
+++ b/skills/expose-a2ui-as-agent-tool.md
@@ -1,0 +1,310 @@
+# Skill: Expose a2ui-4k rendering to an agent as the `render_a2ui` tool
+
+Wire an agent that supports client-side tool calling (AG-UI, OpenAI,
+Gemini, Anthropic) into an a2ui-4k client app so that the agent can
+call `render_a2ui(surfaceId, catalogId, components, data)` and the
+client renders the resulting surface. After this skill is applied the
+app gets a clean tool-call round-trip (agent → client → rendered UI →
+`ToolMessage` → agent resumes) and can delete any bespoke
+`ACTIVITY_SNAPSHOT` handler that was driving `SurfaceStateManager`
+directly.
+
+### Library version vs. tool-adapter layer — read this first
+
+This skill adds a single canonical tool helper shipped by the
+`a2ui-4k` library plus a thin SDK-specific adapter that lives in the
+**app**. The two layers are independent:
+
+| Axis | What it is | Who owns it |
+|---|---|---|
+| **`A2UiRenderTool`** (library) | A pure `JsonObject → JsonObject` helper that drives `SurfaceStateManager` through `createSurface` + `updateComponents` + optional `updateDataModel`. Ships the canonical tool `name`, `description`, and JSON-Schema `parameters`. Transport-free; depends on nothing outside `a2ui-4k`. | `com.contextable:a2ui-4k:0.9.3+` |
+| **Tool-executor adapter** (app) | A small class in your app that implements your tool-calling SDK's `ToolExecutor` / `FunctionDeclaration` / tool-handler interface and forwards to `A2UiRenderTool.render(...)`. Typically 3–6 lines. | Your app code |
+
+Why these are independent: the library cannot depend on any specific
+tool-calling SDK (AG-UI, OpenAI, Gemini, …) without pulling that SDK
+into every a2ui-4k consumer. So the SDK glue stays in app code, while
+the rendering logic, description, and schema stay canonical.
+
+This file is a plain Markdown skill. It is intended to be usable by
+any coding agent (Aider, Cline, Cursor, Copilot Workspace, Claude
+Code, …) and also reads top-to-bottom as a human guide.
+
+---
+
+## 1. When to apply this skill
+
+Apply this skill when **all** of the following are true:
+
+- The app depends on `com.contextable:a2ui-4k:0.9.3` (or later).
+- The app has an agent integration that supports client-side tool
+  calling — AG-UI Kotlin SDK, Gemini Kotlin SDK, OpenAI SDK, Anthropic
+  SDK, or equivalent.
+- The app has (or can obtain) a `SurfaceStateManager` instance that is
+  bound to the Compose `A2UISurface` composable that renders surfaces.
+
+Strong signals the app currently needs this skill (grep these):
+
+| Pattern | File types | What it means |
+|---|---|---|
+| `ACTIVITY_SNAPSHOT` handler that calls `SurfaceStateManager.processMessage` | `*.kt` | App is consuming the server-side middleware pattern. The tool round-trip never closes. Replace with `A2UiRenderTool`. |
+| `ActivitySnapshotEvent` handler in controller / view-model code | `*.kt` | Same as above — custom event path bypassing the tool interface. |
+| `ToolExecutor` interface references with no `render_a2ui` handler | `*.kt` | App has the AG-UI SDK wired up but never advertised `render_a2ui`. Register it. |
+| `"render_a2ui"` string appearing only in prompts / system messages | `*.kt`, `*.md` | App is asking the agent to call a tool it has not registered. Register it. |
+
+Do **not** apply this skill when:
+
+- The app is the server/agent side. `a2ui-4k` is a **client** rendering
+  library; the tool is called on the client and its execution renders
+  the UI. Server-side tool definitions live in the agent framework
+  (ADK, CopilotRuntime, etc.).
+- The app has no agent integration — it only renders surfaces pushed
+  over a direct a2ui channel. `SurfaceStateManager.processMessage` is
+  already the right entry point; there is no tool to register.
+- The app is on the 0.8.x library. `A2UiRenderTool` is a 0.9.3+ API.
+  Run `migrate-0.8-to-0.9` first.
+
+---
+
+## 2. Prerequisites
+
+Before making edits:
+
+1. The target app builds cleanly against `com.contextable:a2ui-4k:0.9.3`
+   (or later). Confirm with `./gradlew build` (or the app's equivalent).
+2. You can locate **the** `SurfaceStateManager` instance that the
+   rendering `A2UISurface` composable reads from. If there are
+   multiple, identify the one bound to the on-screen surface. If you
+   cannot find it, stop and ask the user.
+3. You know which tool-calling SDK the app integrates with (AG-UI
+   Kotlin, Gemini, OpenAI, Anthropic, custom). The adapter snippet
+   you write depends on this.
+4. Working tree is clean so the agent's changes are diffable.
+
+---
+
+## 3. Integration steps
+
+### Step 1 — Instantiate `A2UiRenderTool`
+
+**Detect** (grep): `A2UiRenderTool` — zero matches expected before this step.
+
+**Before:** The app has a `SurfaceStateManager` instance wired into the
+renderer but no `A2UiRenderTool` alongside it.
+
+```kotlin
+val surfaceStateManager = SurfaceStateManager()
+// surfaceStateManager is passed to A2UISurface(...) and previously fed
+// directly by an ACTIVITY_SNAPSHOT handler.
+```
+
+**After:**
+
+```kotlin
+import com.contextable.a2ui4k.agent.A2UiRenderTool
+
+val surfaceStateManager = SurfaceStateManager()
+val renderTool = A2UiRenderTool(surfaceStateManager)
+```
+
+**Check:** `renderTool.name == "render_a2ui"`; `renderTool.parameters`
+is a non-null `JsonObject` with a `required` array containing
+`surfaceId` and `components`.
+
+### Step 2 — Wrap in your SDK's tool-executor
+
+**Detect** (grep): how existing tools are registered in the app —
+`ToolExecutor`, `FunctionDeclaration`, `Tool(...)`, etc.
+
+**Before:** No `render_a2ui` handler is wired into the tool registry.
+
+**After** — pick one of the following adapters based on the app's
+tool-calling SDK.
+
+#### AG-UI Kotlin SDK
+
+```kotlin
+import com.contextable.a2ui4k.agent.A2UiRenderException
+import com.contextable.a2ui4k.agent.A2UiRenderTool
+import kotlinx.serialization.json.JsonObject
+
+class RenderA2UiToolExecutor(private val tool: A2UiRenderTool) : ToolExecutor {
+    override val name = tool.name
+    override val description = tool.description
+    override val parameters = tool.parameters
+    override suspend fun execute(arguments: JsonObject) = try {
+        ToolExecutionResult.success(tool.render(arguments).toString())
+    } catch (e: A2UiRenderException) {
+        ToolExecutionResult.failure(e.message ?: "render_a2ui failed")
+    }
+}
+```
+
+#### Gemini Kotlin SDK (`com.google.ai.client.generativeai`)
+
+```kotlin
+val renderA2UiFunction = defineFunction(
+    name = renderTool.name,
+    description = renderTool.description,
+    // Gemini uses its own schema type; serialize parameters to that shape.
+    // See the Gemini SDK docs for the exact helper; most apps already
+    // have a `jsonSchemaToGeminiSchema` adapter or equivalent.
+) { args ->
+    try {
+        JSONObject(renderTool.render(args.toA2uiJsonObject()).toString())
+    } catch (e: A2UiRenderException) {
+        JSONObject(mapOf("error" to e.message))
+    }
+}
+```
+
+#### OpenAI / Anthropic SDK (generic shape)
+
+Both SDKs take a name, description, and JSON Schema parameters at
+registration time and dispatch tool calls to a handler by name. The
+adapter collapses to:
+
+```kotlin
+tools.register(
+    name = renderTool.name,
+    description = renderTool.description,
+    parameters = renderTool.parameters,
+) { arguments: JsonObject ->
+    try {
+        renderTool.render(arguments).toString()
+    } catch (e: A2UiRenderException) {
+        """{"error":${Json.encodeToString(e.message ?: "render_a2ui failed")}}"""
+    }
+}
+```
+
+**Check:** Your SDK's tool-registration log lists `render_a2ui` among
+the tools sent with each request. For AG-UI specifically, the agent-
+side log should read
+`Tools from frontend: [..., 'render_a2ui']`.
+
+### Step 3 — Register the adapter with the tool registry
+
+**Detect** (grep): the registration site — `registerTool`,
+`addTool`, `tools += ...`, etc.
+
+**Before:** the tool registry has no `render_a2ui` entry.
+
+**After:**
+
+```kotlin
+toolRegistry.registerTool(RenderA2UiToolExecutor(renderTool))
+```
+
+**Check:** After running the app once, the agent-side log shows a
+closed HITL round-trip on the first `render_a2ui` call:
+
+```
+[EXEC] HITL_RESUME ... tool_results=['call_...']
+Removed tool call ... from pending list
+```
+
+If the `Removed tool call` line never appears, the round-trip is still
+open — see Step 4 and the runtime troubleshooting section.
+
+### Step 4 — Delete any bespoke `ACTIVITY_SNAPSHOT` / middleware handler
+
+**Detect** (grep):
+
+| Pattern | File types |
+|---|---|
+| `ActivitySnapshotEvent` | `*.kt` |
+| `"ACTIVITY_SNAPSHOT"` string literals in event handling | `*.kt` |
+| Any custom handler that calls `SurfaceStateManager.processMessage(...)` with a JsonObject parsed from an event stream | `*.kt` |
+
+**Before:** Your controller or view-model has a handler that intercepts
+streamed `ACTIVITY_SNAPSHOT` events and calls
+`SurfaceStateManager.processMessage` directly:
+
+```kotlin
+fun onActivitySnapshot(event: ActivitySnapshotEvent) {
+    surfaceStateManager.processMessage(event.payload)
+}
+```
+
+**After:** Delete the handler. The `render_a2ui` tool executor
+registered in Step 3 now owns the path from agent → surface. Two paths
+feeding the same `SurfaceStateManager` will double-render surfaces
+and race on data-model updates.
+
+**Check:** Run the app and confirm surfaces still render — this time
+through the tool-call path — and that no surface renders twice on the
+same agent turn.
+
+---
+
+## 4. Verification
+
+Build and test:
+
+```bash
+./gradlew build -x compileKotlinIosArm64 -x compileKotlinIosX64 \
+    -x compileKotlinIosSimulatorArm64 -x commonizeNativeDistribution
+./gradlew allTests
+```
+
+End-to-end smoke with a live agent:
+
+1. Start the agent (e.g., an ADK-backed server via `ag_ui_adk`).
+2. Prompt it to render a simple surface — e.g., "show me a card with
+   one button labeled Hello". The agent should call `render_a2ui`.
+3. Confirm the surface appears in the app, driven by the tool call
+   rather than an `ACTIVITY_SNAPSHOT` event.
+4. On the agent side, confirm the tool-result round-trip closes —
+   logs show `HITL_RESUME` / `Removed tool call ... from pending list`.
+5. Tap a button in the rendered surface. The resulting `action` event
+   should round-trip back to the agent via the existing
+   `A2UISurface.onEvent` path. (That path is unchanged by this skill.)
+
+---
+
+## 4a. Runtime verification — "LLM calls the tool but X"
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Tool call reaches the adapter but nothing renders | Adapter is wired to a **different** `SurfaceStateManager` instance than the one `A2UISurface` reads from. | Pass the same `SurfaceStateManager` instance to both `A2UISurface` and `A2UiRenderTool`. |
+| SDK rejects the JSON Schema at registration time | The SDK dislikes `additionalProperties: false` (Gemini has historically been strict here) or requires a flat schema. | Serialize `renderTool.parameters` into the SDK's preferred shape. Do not change the schema shipped by the library. |
+| LLM never calls `render_a2ui` | Description is too terse, or the system prompt routes rendering to a different tool. | Leave `renderTool.description` as the default and make sure the system prompt references `render_a2ui` by name with an example. |
+| HITL round-trip stays open (`Removed tool call` never appears) | The adapter is throwing an uncaught exception instead of returning a `ToolExecutionResult`. | Wrap the `render(...)` call in `try / catch (A2UiRenderException)` and map to the SDK's failure result. |
+| Surface renders twice on every agent turn | A bespoke `ACTIVITY_SNAPSHOT` handler is still driving `SurfaceStateManager.processMessage` alongside the tool path. | Complete Step 4 — delete the legacy handler. |
+| `A2UiRenderException: 'surfaceId' is required` | LLM omitted `surfaceId`. | Usually a weak system prompt. Reinforce that every `render_a2ui` call must specify a stable `surfaceId`. |
+
+---
+
+## 5. What NOT to change
+
+- Do not fork `A2UiRenderTool.description` or `A2UiRenderTool.parameters`
+  unless you genuinely need to. Both are library-owned and shared across
+  every Kotlin host so LLMs see a consistent contract. If you need a
+  different description, override it via the constructor param rather
+  than patching the library.
+- Do not re-implement the `createSurface` → `updateComponents` →
+  `updateDataModel` sequence in the adapter. The library owns that
+  flow; the adapter is a transport shim.
+- Do not swallow `A2UiRenderException` and return success anyway. The
+  LLM needs to see the failure result to recover.
+- Do not change the tool's `name` (`"render_a2ui"`). It is the
+  contract other parts of the ecosystem — including
+  `@copilotkit/a2ui-renderer` on the React side — advertise to agents.
+
+---
+
+## 6. Reference map
+
+| File | Purpose |
+|---|---|
+| `../library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt` | The library-side helper class + `A2UiRenderException`. |
+| `../library/src/commonMain/kotlin/com/contextable/a2ui4k/state/SurfaceStateManager.kt` | The downstream `processMessage(JsonObject)` entry point that `A2UiRenderTool` drives. |
+| `../library/src/commonMain/kotlin/com/contextable/a2ui4k/extension/A2UIExtension.kt` | Catalog-URI constants, including `STANDARD_CATALOG_URI` (default) and `BASIC_CATALOG_URI_V09` (wire-compat). |
+
+---
+
+## 7. Sources
+
+- Library source: [../library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt](../library/src/commonMain/kotlin/com/contextable/a2ui4k/agent/A2UiRenderTool.kt)
+- Upstream A2UI spec: <https://github.com/google/A2UI>
+- Reference React implementation (structural analog): `@copilotkit/a2ui-renderer`


### PR DESCRIPTION
Introduces A2UiRenderTool in a new com.contextable.a2ui4k.agent package — a transport-agnostic helper that drives SurfaceStateManager through the canonical createSurface + updateComponents + optional updateDataModel flow from a single JsonObject tool-call argument. Consumers wrap it in their SDK's ToolExecutor in ~4 lines, which closes the tool-result round-trip that the middleware-only pattern leaves open in ag_ui_adk's HITL loop. No new dependencies; the library stays transport-free.

Also adds A2UIExtension.BASIC_CATALOG_URI_V09 plus a SurfaceStateManager branch-match so agents emitting either the github.com or a2ui.org v0.9 catalog URI resolve cleanly to ProtocolVersion.V0_9.

Ships with a skill (skills/expose-a2ui-as-agent-tool.md) walking through SDK adapter patterns and deletion of legacy ACTIVITY_SNAPSHOT handlers.